### PR TITLE
API improvements

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,18 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use num_bigint::ToBigInt;
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 use topstitch::{EmitConfig, ModDef, IO};
 
 fn main() {
     // Path to Verilog files
 
-    let adder = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("examples")
-        .join("input")
-        .join("adder.sv");
-    let adder = std::fs::read_to_string(adder).unwrap();
-    let adder = ModDef::from_verilog("adder", &adder, true, EmitConfig::Leaf);
+    let adder = ModDef::from_verilog_file(
+        "adder",
+        &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples")
+            .join("input")
+            .join("adder.sv"),
+        true,
+        EmitConfig::Leaf,
+    );
 
     // Create a top-level module definition
 
@@ -47,12 +50,10 @@ fn main() {
     sum.connect(&adder3.get_port("sum"), 0);
 
     // Emit the final Verilog code
-    fs::write(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    top.emit_to_file(
+        &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("examples")
             .join("output")
             .join("top.sv"),
-        top.emit(),
-    )
-    .unwrap();
+    );
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 use topstitch::{
-    EmitConfig, ModDef,
+    ModDef, Usage,
     IO::{Input, Output},
 };
 
@@ -17,7 +17,7 @@ fn main() {
         "adder",
         &examples.join("input").join("adder.sv"),
         true,
-        EmitConfig::Leaf,
+        Usage::EmitDefinitionAndStop,
     );
 
     // Create a top-level module definition

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,8 +7,12 @@ use topstitch::{
 };
 
 fn main() {
-    // Path to Verilog files
+    // Path to the "examples" folder
+
     let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+
+    // Import the adder module definition from a Verilog file
+
     let adder = ModDef::from_verilog_file(
         "adder",
         &examples.join("input").join("adder.sv"),
@@ -39,7 +43,7 @@ fn main() {
     adder1.get_port("b").connect(&in1); // order doesn't matter
 
     in2.connect(&adder2.get_port("a"));
-    adder2.get_port("b").tieoff(42);
+    adder2.get_port("b").tieoff(42); // required because unconnected inputs are not allowed
 
     adder1.get_port("sum").connect(&adder3.get_port("a"));
     adder2.get_port("sum").connect(&adder3.get_port("b"));
@@ -49,5 +53,6 @@ fn main() {
     sum.connect(&adder3.get_port("sum"));
 
     // Emit the final Verilog code
+
     top.emit_to_file(&examples.join("output").join("top.sv"));
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use num_bigint::ToBigInt;
 use std::path::PathBuf;
 use topstitch::{EmitConfig, ModDef, IO};
 
@@ -40,7 +39,7 @@ fn main() {
     adder1.get_port("b").connect(&in1, 0); // order doesn't matter
 
     in2.connect(&adder2.get_port("a"), 0);
-    adder2.get_port("b").tieoff(42.to_bigint().unwrap());
+    adder2.get_port("b").tieoff(42);
 
     adder1.get_port("sum").connect(&adder3.get_port("a"), 0);
     adder2.get_port("sum").connect(&adder3.get_port("b"), 0);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
-use topstitch::{EmitConfig, ModDef, IO};
+use topstitch::{
+    EmitConfig, ModDef,
+    IO::{Input, Output},
+};
 
 fn main() {
     // Path to Verilog files
-
+    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
     let adder = ModDef::from_verilog_file(
         "adder",
-        &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("examples")
-            .join("input")
-            .join("adder.sv"),
+        &examples.join("input").join("adder.sv"),
         true,
         EmitConfig::Leaf,
     );
@@ -22,10 +22,10 @@ fn main() {
 
     // Add ports to the top-level module
 
-    let in0 = top.add_port("in0", IO::Input(8));
-    let in1 = top.add_port("in1", IO::Input(8));
-    let in2 = top.add_port("in2", IO::Input(8));
-    let sum = top.add_port("sum", IO::Output(8));
+    let in0 = top.add_port("in0", Input(8));
+    let in1 = top.add_port("in1", Input(8));
+    let in2 = top.add_port("in2", Input(8));
+    let sum = top.add_port("sum", Output(8));
 
     // Instantiate adders
 
@@ -35,24 +35,19 @@ fn main() {
 
     // Wire together adders in a tree
 
-    in0.connect(&adder1.get_port("a"), 0);
-    adder1.get_port("b").connect(&in1, 0); // order doesn't matter
+    in0.connect(&adder1.get_port("a"));
+    adder1.get_port("b").connect(&in1); // order doesn't matter
 
-    in2.connect(&adder2.get_port("a"), 0);
+    in2.connect(&adder2.get_port("a"));
     adder2.get_port("b").tieoff(42);
 
-    adder1.get_port("sum").connect(&adder3.get_port("a"), 0);
-    adder2.get_port("sum").connect(&adder3.get_port("b"), 0);
+    adder1.get_port("sum").connect(&adder3.get_port("a"));
+    adder2.get_port("sum").connect(&adder3.get_port("b"));
 
     // Connect the final adder output the top-level output
 
-    sum.connect(&adder3.get_port("sum"), 0);
+    sum.connect(&adder3.get_port("sum"));
 
     // Emit the final Verilog code
-    top.emit_to_file(
-        &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("examples")
-            .join("output")
-            .join("top.sv"),
-    );
+    top.emit_to_file(&examples.join("output").join("top.sv"));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,7 +900,7 @@ impl Port {
         self.to_port_slice().connect(other, _pipeline);
     }
 
-    pub fn tieoff(&self, value: BigInt) {
+    pub fn tieoff<T: Into<BigInt>>(&self, value: T) {
         self.to_port_slice().tieoff(value);
     }
 
@@ -999,12 +999,12 @@ impl PortSlice {
         mod_def_core.borrow_mut().assignments.push((lhs, rhs));
     }
 
-    pub fn tieoff(&self, value: BigInt) {
+    pub fn tieoff<T: Into<BigInt>>(&self, value: T) {
         let mod_def_core = self.get_mod_def_core();
         mod_def_core
             .borrow_mut()
             .tieoffs
-            .push(((*self).clone(), value));
+            .push(((*self).clone(), value.into()));
     }
 
     pub fn unused(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use num_bigint::BigInt;
 use slang_rs::extract_ports;
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::path::Path;
 use std::rc::{Rc, Weak};
 use xlsynth::vast::{Expr, LogicRef, VastFile, VastFileType};
 
@@ -180,12 +181,22 @@ impl ModDef {
         }
     }
 
+    pub fn from_verilog_file(
+        name: &str,
+        verilog: &Path,
+        ignore_unknown_modules: bool,
+        emit_config: EmitConfig,
+    ) -> Self {
+        let verilog = std::fs::read_to_string(verilog).unwrap();
+        ModDef::from_verilog(name, &verilog, ignore_unknown_modules, emit_config)
+    }
+
     pub fn from_verilog(
         name: &str,
         verilog: &str,
         ignore_unknown_modules: bool,
         emit_config: EmitConfig,
-    ) -> ModDef {
+    ) -> Self {
         let parser_ports = extract_ports(verilog, ignore_unknown_modules);
 
         let mut ports = IndexMap::new();
@@ -311,6 +322,10 @@ impl ModDef {
         }
 
         inst
+    }
+
+    pub fn emit_to_file(&self, path: &Path) {
+        std::fs::write(path, self.emit()).unwrap();
     }
 
     pub fn emit(&self) -> String {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -29,13 +29,13 @@ mod tests {
 
         a_inst
             .get_port("a_axi_m_wvalid")
-            .connect(&b_inst.get_port("b_axi_s_wvalid"), 0);
+            .connect(&b_inst.get_port("b_axi_s_wvalid"));
         a_inst
             .get_port("a_axi_m_wready")
-            .connect(&b_inst.get_port("b_axi_s_wready"), 0);
+            .connect(&b_inst.get_port("b_axi_s_wready"));
         a_inst
             .get_port("a_axi_m_wdata")
-            .connect(&b_inst.get_port("b_axi_s_wdata"), 0);
+            .connect(&b_inst.get_port("b_axi_s_wdata"));
 
         assert_eq!(
             c_mod_def.emit(),
@@ -109,13 +109,13 @@ endmodule";
 
         a_inst
             .get_port("a_axi_m_wvalid")
-            .connect(&b_inst.get_port("b_axi_s_wvalid"), 0);
+            .connect(&b_inst.get_port("b_axi_s_wvalid"));
         a_inst
             .get_port("a_axi_m_wready")
-            .connect(&b_inst.get_port("b_axi_s_wready"), 0);
+            .connect(&b_inst.get_port("b_axi_s_wready"));
         a_inst
             .get_port("a_axi_m_wdata")
-            .connect(&b_inst.get_port("b_axi_s_wdata"), 0);
+            .connect(&b_inst.get_port("b_axi_s_wdata"));
 
         assert_eq!(
             c_mod_def.emit(),
@@ -193,8 +193,8 @@ endmodule
         let b1 = a_mod_def.instantiate(&b_mod_def, "b1", None);
 
         let a_bus = a_mod_def.get_port("bus");
-        b0.get_port("half_bus").connect(&a_bus.slice(3, 0), 0);
-        a_bus.slice(7, 4).connect(&b1.get_port("half_bus"), 0);
+        b0.get_port("half_bus").connect(&a_bus.slice(3, 0));
+        a_bus.slice(7, 4).connect(&b1.get_port("half_bus"));
 
         assert_eq!(
             a_mod_def.emit(),
@@ -256,7 +256,7 @@ endmodule
         let a_intf = a_inst.get_intf("a_intf");
         let b_intf = b_inst.get_intf("b_intf");
 
-        a_intf.connect(&b_intf, 0, false);
+        a_intf.connect(&b_intf, false);
 
         assert_eq!(
             top_module.emit(),
@@ -310,7 +310,7 @@ endmodule
 
         let mod_a_intf = module_a.get_intf("a");
         let b_intf = b_inst.get_intf("b");
-        mod_a_intf.connect(&b_intf, 0, false);
+        mod_a_intf.connect(&b_intf, false);
 
         assert_eq!(
             module_a.emit(),
@@ -354,7 +354,7 @@ endmodule
         let a_intf = module.get_intf("a_intf");
         let b_intf = module.get_intf("b_intf");
 
-        a_intf.connect(&b_intf, 0, false);
+        a_intf.connect(&b_intf, false);
 
         assert_eq!(
             module.emit(),
@@ -456,7 +456,7 @@ endmodule
     #[test]
     fn test_feedthrough() {
         let mod_def = ModDef::new("TestModule");
-        mod_def.feedthrough("input_signal", "output_signal", 8, 0);
+        mod_def.feedthrough("input_signal", "output_signal", 8);
         assert_eq!(
             mod_def.emit(),
             "\
@@ -479,7 +479,7 @@ endmodule
 
         original_mod.def_intf_from_prefix("data_intf", "data_");
 
-        let wrapped_mod = original_mod.wrap(None, None, 0);
+        let wrapped_mod = original_mod.wrap(None, None);
 
         let top_mod = ModDef::new("TopModule");
         let wrapped_inst = top_mod.instantiate(&wrapped_mod, "wrapped_inst", None);
@@ -583,8 +583,8 @@ endmodule
         let in_port1 = mod_def.add_port("in1", IO::Input(1));
         let in_port2 = mod_def.add_port("in2", IO::Input(1));
 
-        out_port.connect(&in_port1, 0);
-        out_port.connect(&in_port2, 0);
+        out_port.connect(&in_port1);
+        out_port.connect(&in_port2);
 
         mod_def.validate(); // Should panic
     }
@@ -614,8 +614,8 @@ endmodule
 
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
 
-        inst.get_port("in").connect(&in_port1, 0);
-        inst.get_port("in").connect(&in_port2, 0);
+        inst.get_port("in").connect(&in_port1);
+        inst.get_port("in").connect(&in_port2);
 
         parent.validate(); // Should panic
     }
@@ -666,7 +666,7 @@ endmodule
         let mod_def = ModDef::new("TestMod");
         let in_port_0 = mod_def.add_port("in0", IO::Input(1));
         let in_port_1 = mod_def.add_port("in1", IO::Input(1));
-        in_port_0.connect(&in_port_1, 0);
+        in_port_0.connect(&in_port_1);
         mod_def.validate(); // Should panic
     }
 
@@ -681,7 +681,7 @@ endmodule
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
 
         let in_port = parent.add_port("in", IO::Input(1));
-        inst.get_port("out").connect(&in_port, 0);
+        inst.get_port("out").connect(&in_port);
 
         parent.validate(); // Should panic
     }
@@ -695,7 +695,7 @@ endmodule
         let mod_def_2 = ModDef::new("ModDef2");
         let port_2 = mod_def_2.add_port("in", IO::Input(1));
 
-        port_1.connect(&port_2, 0);
+        port_1.connect(&port_2);
 
         mod_def_1.validate(); // Should panic
     }
@@ -714,7 +714,7 @@ endmodule
         let parent2 = ModDef::new("ParentMod2");
         let inst2 = parent2.instantiate(&leaf, "leaf_inst2", None);
 
-        inst1.get_port("out").connect(&inst2.get_port("in"), 0);
+        inst1.get_port("out").connect(&inst2.get_port("in"));
 
         parent1.validate(); // Should panic
     }
@@ -725,7 +725,7 @@ endmodule
         let in_port = mod_def.add_port("in", IO::Input(1));
         let out_port = mod_def.add_port("out", IO::Output(1));
 
-        out_port.connect(&in_port, 0);
+        out_port.connect(&in_port);
 
         mod_def.validate(); // Should pass
     }
@@ -743,8 +743,8 @@ endmodule
         let parent_in = parent.add_port("in", IO::Input(1));
         let parent_out = parent.add_port("out", IO::Output(1));
 
-        inst.get_port("in").connect(&parent_in, 0);
-        parent_out.connect(&inst.get_port("out"), 0);
+        inst.get_port("in").connect(&parent_in);
+        parent_out.connect(&inst.get_port("out"));
 
         parent.validate(); // Should pass
     }
@@ -823,8 +823,8 @@ endmodule
         bus_b.slice(0, 0).unused();
         bus_b.slice(7, 7).unused();
 
-        out_port.connect(&bus_a, 0);
-        out_port.slice(6, 1).connect(&bus_b.slice(6, 1), 0);
+        out_port.connect(&bus_a);
+        out_port.slice(6, 1).connect(&bus_b.slice(6, 1));
 
         mod_def.validate(); // Should panic
     }
@@ -835,8 +835,8 @@ endmodule
         let in_port = mod_def.add_port("in", IO::Input(8));
         let out_port = mod_def.add_port("out", IO::Output(8));
 
-        out_port.slice(0, 0).connect(&in_port.slice(0, 0), 0);
-        out_port.slice(7, 7).connect(&in_port.slice(7, 7), 0);
+        out_port.slice(0, 0).connect(&in_port.slice(0, 0));
+        out_port.slice(7, 7).connect(&in_port.slice(7, 7));
         out_port.slice(6, 1).tieoff(0);
 
         in_port.slice(6, 1).unused();
@@ -851,8 +851,8 @@ endmodule
         let in_port = mod_def.add_port("in", IO::Input(8));
         let out_port = mod_def.add_port("out", IO::Output(8));
 
-        out_port.slice(0, 0).connect(&in_port.slice(0, 0), 0);
-        out_port.slice(7, 7).connect(&in_port.slice(7, 7), 0);
+        out_port.slice(0, 0).connect(&in_port.slice(0, 0));
+        out_port.slice(7, 7).connect(&in_port.slice(7, 7));
         out_port.slice(6, 1).tieoff(0);
 
         mod_def.validate(); // Should panic

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,7 +2,6 @@
 
 mod tests {
 
-    use num_bigint::ToBigInt;
     use topstitch::*;
 
     #[test]
@@ -165,9 +164,7 @@ endmodule
         // Define module A
         let a_mod_def = ModDef::new("A");
         a_mod_def.add_port("constant", IO::Output(8));
-        a_mod_def
-            .get_port("constant")
-            .tieoff(42.to_bigint().unwrap());
+        a_mod_def.get_port("constant").tieoff(42);
 
         assert_eq!(
             a_mod_def.emit(),
@@ -761,7 +758,7 @@ endmodule
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
 
-        inst.get_port("in").tieoff(0.to_bigint().unwrap());
+        inst.get_port("in").tieoff(0);
 
         parent.validate(); // Should pass
     }
@@ -771,7 +768,7 @@ endmodule
         let mod_def = ModDef::new("TestMod");
         let out_port = mod_def.add_port("out", IO::Output(1));
 
-        out_port.tieoff(1.to_bigint().unwrap());
+        out_port.tieoff(1);
 
         mod_def.validate(); // Should pass
     }
@@ -782,7 +779,7 @@ endmodule
         let mod_def = ModDef::new("TestMod");
         let in_port = mod_def.add_port("in", IO::Input(1));
 
-        in_port.tieoff(0.to_bigint().unwrap());
+        in_port.tieoff(0);
 
         mod_def.validate(); // Should panic
     }
@@ -797,7 +794,7 @@ endmodule
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
 
-        inst.get_port("out").tieoff(0.to_bigint().unwrap());
+        inst.get_port("out").tieoff(0);
 
         parent.validate(); // Should panic
     }
@@ -809,8 +806,8 @@ endmodule
         let mod_def = ModDef::new("TestMod");
         let out_port = mod_def.add_port("out", IO::Output(8));
 
-        out_port.slice(7, 0).tieoff(0.to_bigint().unwrap());
-        out_port.slice(6, 1).tieoff(1.to_bigint().unwrap());
+        out_port.slice(7, 0).tieoff(0);
+        out_port.slice(6, 1).tieoff(1);
 
         mod_def.validate(); // Should panic
     }
@@ -840,7 +837,7 @@ endmodule
 
         out_port.slice(0, 0).connect(&in_port.slice(0, 0), 0);
         out_port.slice(7, 7).connect(&in_port.slice(7, 7), 0);
-        out_port.slice(6, 1).tieoff(0.to_bigint().unwrap());
+        out_port.slice(6, 1).tieoff(0);
 
         in_port.slice(6, 1).unused();
 
@@ -856,7 +853,7 @@ endmodule
 
         out_port.slice(0, 0).connect(&in_port.slice(0, 0), 0);
         out_port.slice(7, 7).connect(&in_port.slice(7, 7), 0);
-        out_port.slice(6, 1).tieoff(0.to_bigint().unwrap());
+        out_port.slice(6, 1).tieoff(0);
 
         mod_def.validate(); // Should panic
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,14 +11,14 @@ mod tests {
         a_mod_def.add_port("a_axi_m_wvalid", IO::Output(1));
         a_mod_def.add_port("a_axi_m_wdata", IO::Output(8));
         a_mod_def.add_port("a_axi_m_wready", IO::Input(1));
-        a_mod_def.core.borrow_mut().emit_config = EmitConfig::Stub;
+        a_mod_def.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         // Define module B
         let b_mod_def = ModDef::new("B");
         b_mod_def.add_port("b_axi_s_wvalid", IO::Input(1));
         b_mod_def.add_port("b_axi_s_wdata", IO::Input(8));
         b_mod_def.add_port("b_axi_s_wready", IO::Output(1));
-        b_mod_def.core.borrow_mut().emit_config = EmitConfig::Stub;
+        b_mod_def.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         // Define module C
         let c_mod_def: ModDef = ModDef::new("C");
@@ -97,8 +97,8 @@ module B(
 );
   wire bar;
 endmodule";
-        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, EmitConfig::Leaf);
-        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, EmitConfig::Stub);
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, Usage::EmitDefinitionAndStop);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, Usage::EmitStubAndStop);
 
         // Define module C
         let c_mod_def: ModDef = ModDef::new("C");
@@ -187,7 +187,7 @@ endmodule
         // Define module B
         let b_mod_def = ModDef::new("B");
         b_mod_def.add_port("half_bus", IO::Input(4));
-        b_mod_def.core.borrow_mut().emit_config = EmitConfig::Stub;
+        b_mod_def.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let b0 = a_mod_def.instantiate(&b_mod_def, "b0", None);
         let b1 = a_mod_def.instantiate(&b_mod_def, "b1", None);
@@ -242,10 +242,12 @@ endmodule
     endmodule
     ";
 
-        let module_a = ModDef::from_verilog("ModuleA", module_a_verilog, true, EmitConfig::Nothing);
+        let module_a =
+            ModDef::from_verilog("ModuleA", module_a_verilog, true, Usage::EmitNothingAndStop);
         module_a.def_intf_from_prefix("a_intf", "a_");
 
-        let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, EmitConfig::Nothing);
+        let module_b =
+            ModDef::from_verilog("ModuleB", module_b_verilog, true, Usage::EmitNothingAndStop);
         module_b.def_intf_from_prefix("b_intf", "b_");
 
         let top_module = ModDef::new("TopModule");
@@ -297,7 +299,8 @@ endmodule
     endmodule
     ";
 
-        let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, EmitConfig::Nothing);
+        let module_b =
+            ModDef::from_verilog("ModuleB", module_b_verilog, true, Usage::EmitNothingAndStop);
         module_b.def_intf_from_prefix("b", "b_");
 
         let module_a = ModDef::new("ModuleA");
@@ -387,7 +390,8 @@ endmodule
     endmodule
     ";
 
-        let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, EmitConfig::Nothing);
+        let module_b =
+            ModDef::from_verilog("ModuleB", module_b_verilog, true, Usage::EmitNothingAndStop);
         module_b.def_intf_from_prefix("b", "b_");
 
         let module_a = ModDef::new("ModuleA");
@@ -430,7 +434,8 @@ endmodule
     endmodule
     ";
 
-        let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, EmitConfig::Nothing);
+        let module_b =
+            ModDef::from_verilog("ModuleB", module_b_verilog, true, Usage::EmitNothingAndStop);
         let module_a = ModDef::new("ModuleA");
 
         let b_inst = module_a.instantiate(&module_b, "inst_b", None);
@@ -475,7 +480,7 @@ endmodule
         let original_mod = ModDef::new("OriginalModule");
         original_mod.add_port("data_in", IO::Input(16));
         original_mod.add_port("data_out", IO::Output(16));
-        original_mod.core.borrow_mut().emit_config = EmitConfig::Nothing;
+        original_mod.core.borrow_mut().usage = Usage::EmitNothingAndStop;
 
         original_mod.def_intf_from_prefix("data_intf", "data_");
 
@@ -531,7 +536,7 @@ endmodule
         child_mod.add_port("clk", IO::Input(1));
         child_mod.add_port("rst", IO::Input(1));
         child_mod.add_port("data", IO::Output(8));
-        child_mod.core.borrow_mut().emit_config = EmitConfig::Stub;
+        child_mod.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let autoconnect_ports = ["clk", "rst", "nonexistent"];
         let child_inst = parent_mod.instantiate(&child_mod, "child_inst", Some(&autoconnect_ports));
@@ -594,7 +599,7 @@ endmodule
     fn test_modinst_input_undriven() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("in", IO::Input(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         parent.instantiate(&leaf, "leaf_inst", None);
@@ -606,7 +611,7 @@ endmodule
     fn test_modinst_input_multiple_drivers() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("in", IO::Input(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         let in_port1 = parent.add_port("in1", IO::Input(1));
@@ -641,7 +646,7 @@ endmodule
     fn test_modinst_output_not_driving_anything() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("out", IO::Output(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         parent.instantiate(&leaf, "leaf_inst", None);
@@ -652,7 +657,7 @@ endmodule
     fn test_modinst_output_unused() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("out", IO::Output(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
@@ -675,7 +680,7 @@ endmodule
     fn test_modinst_output_driven_within_moddef() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("out", IO::Output(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
@@ -706,7 +711,7 @@ endmodule
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("in", IO::Input(1));
         leaf.add_port("out", IO::Output(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent1 = ModDef::new("ParentMod1");
         let inst1 = parent1.instantiate(&leaf, "leaf_inst1", None);
@@ -735,7 +740,7 @@ endmodule
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("in", IO::Input(1));
         leaf.add_port("out", IO::Output(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
@@ -753,7 +758,7 @@ endmodule
     fn test_tieoff_modinst_input() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("in", IO::Input(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);
@@ -789,7 +794,7 @@ endmodule
     fn test_invalid_tieoff_modinst_output() {
         let leaf = ModDef::new("LeafMod");
         leaf.add_port("out", IO::Output(1));
-        leaf.core.borrow_mut().emit_config = EmitConfig::Stub;
+        leaf.core.borrow_mut().usage = Usage::EmitStubAndStop;
 
         let parent = ModDef::new("ParentMod");
         let inst = parent.instantiate(&leaf, "leaf_inst", None);


### PR DESCRIPTION
* `EmitConfig` is renamed `Usage` to capture its more general meaning. Variant names are updated as well.
* The `pipeline` argument to `connect()` is removed for now.
* Added `ModDef.emit_to_file()` and `ModDef.from_verilog_file()` to simplify reading and writing files.
* Error messages are improved.