### PR TITLE
Allow validation to be disabled for prototyping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "indexmap",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -50,5 +50,5 @@ fn main() {
 
     // Emit the final Verilog code
 
-    top.emit_to_file(&examples.join("output").join("top.sv"));
+    top.emit_to_file(&examples.join("output").join("top.sv"), true);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,12 +405,14 @@ impl ModDef {
         inst
     }
 
-    pub fn emit_to_file(&self, path: &Path) {
-        std::fs::write(path, self.emit()).unwrap();
+    pub fn emit_to_file(&self, path: &Path, validate: bool) {
+        std::fs::write(path, self.emit(validate)).unwrap();
     }
 
-    pub fn emit(&self) -> String {
-        self.validate();
+    pub fn emit(&self, validate: bool) -> String {
+        if validate {
+            self.validate();
+        }
         let mut emitted_module_names = IndexMap::new();
         let mut file = VastFile::new(VastFileType::SystemVerilog);
         let mut leaf_text = Vec::new();
@@ -1433,10 +1435,11 @@ impl Intf {
         }
     }
 
-    pub fn tieoff(&self, value: BigInt) {
+    pub fn tieoff<T: Into<BigInt>>(&self, value: T) {
         let core = self.get_mod_def_core();
         let binding = core.borrow();
         let mapping = binding.interfaces.get(&self.get_intf_name()).unwrap();
+        let value: BigInt = value.into();
         for (_, port_name) in mapping {
             ModDef { core: core.clone() }
                 .get_port(port_name)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -40,7 +40,7 @@ mod tests {
         b_mod_def.set_usage(Usage::EmitStubAndStop);
 
         assert_eq!(
-            c_mod_def.emit(),
+            c_mod_def.emit(true),
             "\
 module A(
   output wire a_axi_m_wvalid,
@@ -122,7 +122,7 @@ endmodule";
         b_mod_def.set_usage(Usage::EmitStubAndStop);
 
         assert_eq!(
-            c_mod_def.emit(),
+            c_mod_def.emit(true),
             "\
 module B(
   input wire b_axi_s_wvalid,
@@ -164,7 +164,7 @@ endmodule
         a_mod_def.get_port("constant").tieoff(42);
 
         assert_eq!(
-            a_mod_def.emit(),
+            a_mod_def.emit(true),
             "\
 module A(
   output wire [7:0] constant
@@ -195,7 +195,7 @@ endmodule
         b_mod_def.set_usage(Usage::EmitStubAndStop);
 
         assert_eq!(
-            a_mod_def.emit(),
+            a_mod_def.emit(true),
             "\
 module B(
   input wire [3:0] half_bus
@@ -257,7 +257,7 @@ endmodule
         a_intf.connect(&b_intf, false);
 
         assert_eq!(
-            top_module.emit(),
+            top_module.emit(true),
             "\
 module TopModule;
   wire [31:0] inst_a_a_data;
@@ -311,7 +311,7 @@ endmodule
         mod_a_intf.connect(&b_intf, false);
 
         assert_eq!(
-            module_a.emit(),
+            module_a.emit(true),
             "\
 module ModuleA(
   output wire [31:0] a_data,
@@ -355,7 +355,7 @@ endmodule
         a_intf.connect(&b_intf, false);
 
         assert_eq!(
-            module.emit(),
+            module.emit(true),
             "\
 module MyModule(
   input wire [31:0] a_data,
@@ -395,7 +395,7 @@ endmodule
         b_intf.export_with_prefix("a_");
 
         assert_eq!(
-            module_a.emit(),
+            module_a.emit(true),
             "\
 module ModuleA(
   output wire [31:0] a_data,
@@ -436,7 +436,7 @@ endmodule
         data_out_port.export_as("data_out");
 
         assert_eq!(
-            module_a.emit(),
+            module_a.emit(true),
             "\
 module ModuleA(
   output wire [7:0] data_out
@@ -456,7 +456,7 @@ endmodule
         let mod_def = ModDef::new("TestModule");
         mod_def.feedthrough("input_signal", "output_signal", 8);
         assert_eq!(
-            mod_def.emit(),
+            mod_def.emit(true),
             "\
 module TestModule(
   input wire [7:0] input_signal,
@@ -488,7 +488,7 @@ endmodule
         original_mod.set_usage(Usage::EmitNothingAndStop);
 
         assert_eq!(
-            top_mod.emit(),
+            top_mod.emit(true),
             "\
 module OriginalModule_wrapper(
   input wire [15:0] data_in,
@@ -538,7 +538,7 @@ endmodule
         child_mod.set_usage(Usage::EmitStubAndStop);
 
         assert_eq!(
-            parent_mod.emit(),
+            parent_mod.emit(true),
             "\
 module ChildModule(
   input wire clk,
@@ -894,7 +894,7 @@ endmodule
             .unused();
 
         assert_eq!(
-            top.emit(),
+            top.emit(true),
             "\
 module Orig_W_16(
   output wire [15:0] data


### PR DESCRIPTION
Also implicitly convert to BigInt if needed when tying off interfaces.