### PR TITLE
Default instance name + instance arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +195,15 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -565,9 +580,10 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "indexmap",
+ "itertools",
  "num-bigint",
  "slang-rs",
  "xlsynth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -13,3 +13,4 @@ num-bigint = "0.4.3"
 indexmap = "2.5.0"
 xlsynth = "0.0.26"
 slang-rs = "0.6.0"
+itertools = "0.10"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -24,9 +24,9 @@ fn main() {
 
     // Instantiate adders in a tree
 
-    let i00 = top.instantiate(&adder_8_bit, "i00", None);
-    let i01 = top.instantiate(&adder_8_bit, "i01", None);
-    let i11 = top.instantiate(&adder_9_bit, "i11", None);
+    let i00 = top.instantiate(&adder_8_bit, Some("i00"), None);
+    let i01 = top.instantiate(&adder_8_bit, Some("i01"), None);
+    let i11 = top.instantiate(&adder_9_bit, Some("i11"), None);
 
     let a = top.add_port("in0", i00.get_port("a").io());
     let b = top.add_port("in1", i00.get_port("b").io());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,9 +353,12 @@ impl ModDef {
     pub fn instantiate(
         &self,
         moddef: &ModDef,
-        name: &str,
+        name: Option<&str>,
         autoconnect: Option<&[&str]>,
     ) -> ModInst {
+        let name_default = format!("{}_inst", moddef.core.borrow().name);
+        let name = name.unwrap_or(name_default.as_str());
+
         if self.frozen() {
             panic!(
                 "Module {} is frozen. wrap() first if modifications are needed.",
@@ -697,8 +700,6 @@ impl ModDef {
         let original_name = &self.core.borrow().name;
         let def_name_default = format!("{}_wrapper", original_name);
         let def_name = def_name.unwrap_or(&def_name_default);
-        let inst_name_default = format!("{}_inst", original_name);
-        let inst_name = inst_name.unwrap_or(&inst_name_default);
 
         let wrapper = ModDef::new(def_name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 use indexmap::map::Entry;
 use indexmap::IndexMap;
+use itertools::Itertools;
 use num_bigint::BigInt;
 use slang_rs::{self, extract_ports, str2tmpfile, SlangConfig};
 use std::cell::RefCell;
@@ -406,6 +407,61 @@ impl ModDef {
         }
 
         inst
+    }
+
+    pub fn instantiate_array(
+        &self,
+        moddef: &ModDef,
+        dimensions: &[usize],
+        prefix: Option<&str>,
+    ) -> Vec<ModInst> {
+        if dimensions.is_empty() {
+            panic!("Dimensions array cannot be empty.");
+        }
+        if dimensions.iter().any(|&d| d == 0) {
+            panic!("Dimension sizes must be greater than zero.");
+        }
+
+        // Create a vector of ranges based on dimensions
+        let ranges: Vec<std::ops::Range<usize>> = dimensions.iter().map(|&d| 0..d).collect();
+
+        // Generate all combinations of indices
+        let index_combinations = ranges.into_iter().multi_cartesian_product();
+
+        let mut instances = Vec::new();
+
+        for indices in index_combinations {
+            // Build instance name
+            let indices_str = indices
+                .iter()
+                .map(|&i| i.to_string())
+                .collect::<Vec<String>>()
+                .join("_");
+
+            let instance_name = match prefix {
+                Some(pfx) => {
+                    if indices_str.is_empty() {
+                        pfx.to_string()
+                    } else {
+                        format!("{}_{}", pfx, indices_str)
+                    }
+                }
+                None => {
+                    let moddef_name = &moddef.core.borrow().name;
+                    if indices_str.is_empty() {
+                        format!("{}_inst", moddef_name)
+                    } else {
+                        format!("{}_inst_{}", moddef_name, indices_str)
+                    }
+                }
+            };
+
+            // Instantiate the moddef
+            let inst = self.instantiate(moddef, Some(&instance_name), None);
+            instances.push(inst);
+        }
+
+        instances
     }
 
     pub fn emit_to_file(&self, path: &Path, validate: bool) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -23,8 +23,8 @@ mod tests {
         let c_mod_def: ModDef = ModDef::new("C");
 
         // Instantiate A and B in C
-        let a_inst = c_mod_def.instantiate(&a_mod_def, "inst_a", None);
-        let b_inst = c_mod_def.instantiate(&b_mod_def, "inst_b", None);
+        let a_inst = c_mod_def.instantiate(&a_mod_def, None, None);
+        let b_inst = c_mod_def.instantiate(&b_mod_def, None, None);
 
         a_inst
             .get_port("a_axi_m_wvalid")
@@ -57,25 +57,25 @@ module B(
 
 endmodule
 module C;
-  wire inst_a_a_axi_m_wvalid;
-  wire [7:0] inst_a_a_axi_m_wdata;
-  wire inst_a_a_axi_m_wready;
-  wire inst_b_b_axi_s_wvalid;
-  wire [7:0] inst_b_b_axi_s_wdata;
-  wire inst_b_b_axi_s_wready;
-  A inst_a (
-    .a_axi_m_wvalid(inst_a_a_axi_m_wvalid),
-    .a_axi_m_wdata(inst_a_a_axi_m_wdata),
-    .a_axi_m_wready(inst_a_a_axi_m_wready)
+  wire A_inst_a_axi_m_wvalid;
+  wire [7:0] A_inst_a_axi_m_wdata;
+  wire A_inst_a_axi_m_wready;
+  wire B_inst_b_axi_s_wvalid;
+  wire [7:0] B_inst_b_axi_s_wdata;
+  wire B_inst_b_axi_s_wready;
+  A A_inst (
+    .a_axi_m_wvalid(A_inst_a_axi_m_wvalid),
+    .a_axi_m_wdata(A_inst_a_axi_m_wdata),
+    .a_axi_m_wready(A_inst_a_axi_m_wready)
   );
-  B inst_b (
-    .b_axi_s_wvalid(inst_b_b_axi_s_wvalid),
-    .b_axi_s_wdata(inst_b_b_axi_s_wdata),
-    .b_axi_s_wready(inst_b_b_axi_s_wready)
+  B B_inst (
+    .b_axi_s_wvalid(B_inst_b_axi_s_wvalid),
+    .b_axi_s_wdata(B_inst_b_axi_s_wdata),
+    .b_axi_s_wready(B_inst_b_axi_s_wready)
   );
-  assign inst_b_b_axi_s_wvalid = inst_a_a_axi_m_wvalid;
-  assign inst_a_a_axi_m_wready = inst_b_b_axi_s_wready;
-  assign inst_b_b_axi_s_wdata[7:0] = inst_a_a_axi_m_wdata[7:0];
+  assign B_inst_b_axi_s_wvalid = A_inst_a_axi_m_wvalid;
+  assign A_inst_a_axi_m_wready = B_inst_b_axi_s_wready;
+  assign B_inst_b_axi_s_wdata[7:0] = A_inst_a_axi_m_wdata[7:0];
 endmodule
 "
         );
@@ -106,8 +106,8 @@ endmodule";
         let c_mod_def: ModDef = ModDef::new("C");
 
         // Instantiate A and B in C
-        let a_inst = c_mod_def.instantiate(&a_mod_def, "inst_a", None);
-        let b_inst = c_mod_def.instantiate(&b_mod_def, "inst_b", None);
+        let a_inst = c_mod_def.instantiate(&a_mod_def, Some("inst_a"), None);
+        let b_inst = c_mod_def.instantiate(&b_mod_def, Some("inst_b"), None);
 
         a_inst
             .get_port("a_axi_m_wvalid")
@@ -185,8 +185,8 @@ endmodule
         let b_mod_def = ModDef::new("B");
         b_mod_def.add_port("half_bus", IO::Input(4));
 
-        let b0 = a_mod_def.instantiate(&b_mod_def, "b0", None);
-        let b1 = a_mod_def.instantiate(&b_mod_def, "b1", None);
+        let b0 = a_mod_def.instantiate(&b_mod_def, Some("b0"), None);
+        let b1 = a_mod_def.instantiate(&b_mod_def, Some("b1"), None);
 
         let a_bus = a_mod_def.get_port("bus");
         b0.get_port("half_bus").connect(&a_bus.slice(3, 0));
@@ -248,8 +248,8 @@ endmodule
 
         let top_module = ModDef::new("TopModule");
 
-        let a_inst = top_module.instantiate(&module_a, "inst_a", None);
-        let b_inst = top_module.instantiate(&module_b, "inst_b", None);
+        let a_inst = top_module.instantiate(&module_a, Some("inst_a"), None);
+        let b_inst = top_module.instantiate(&module_b, Some("inst_b"), None);
 
         let a_intf = a_inst.get_intf("a_intf");
         let b_intf = b_inst.get_intf("b_intf");
@@ -304,7 +304,7 @@ endmodule
         module_a.add_port("a_ready", IO::Input(1));
         module_a.def_intf_from_prefix("a", "a_");
 
-        let b_inst = module_a.instantiate(&module_b, "inst_b", None);
+        let b_inst = module_a.instantiate(&module_b, Some("inst_b"), None);
 
         let mod_a_intf = module_a.get_intf("a");
         let b_intf = b_inst.get_intf("b");
@@ -390,7 +390,7 @@ endmodule
 
         let module_a = ModDef::new("ModuleA");
 
-        let b_inst = module_a.instantiate(&module_b, "inst_b", None);
+        let b_inst = module_a.instantiate(&module_b, Some("inst_b"), None);
         let b_intf = b_inst.get_intf("b");
         b_intf.export_with_prefix("a_");
 
@@ -431,7 +431,7 @@ endmodule
         let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, false);
         let module_a = ModDef::new("ModuleA");
 
-        let b_inst = module_a.instantiate(&module_b, "inst_b", None);
+        let b_inst = module_a.instantiate(&module_b, Some("inst_b"), None);
         let data_out_port = b_inst.get_port("data_out");
         data_out_port.export_as("data_out");
 
@@ -479,7 +479,7 @@ endmodule
         let wrapped_mod = original_mod.wrap(None, None);
 
         let top_mod = ModDef::new("TopModule");
-        let wrapped_inst = top_mod.instantiate(&wrapped_mod, "wrapped_inst", None);
+        let wrapped_inst = top_mod.instantiate(&wrapped_mod, Some("wrapped_inst"), None);
 
         wrapped_inst
             .get_intf("data_intf")
@@ -532,7 +532,8 @@ endmodule
         child_mod.add_port("data", IO::Output(8));
 
         let autoconnect_ports = ["clk", "rst", "nonexistent"];
-        let child_inst = parent_mod.instantiate(&child_mod, "child_inst", Some(&autoconnect_ports));
+        let child_inst =
+            parent_mod.instantiate(&child_mod, Some("child_inst"), Some(&autoconnect_ports));
         child_inst.get_port("data").unused();
 
         child_mod.set_usage(Usage::EmitStubAndStop);
@@ -597,7 +598,7 @@ endmodule
         leaf.add_port("in", IO::Input(1));
 
         let parent = ModDef::new("ParentMod");
-        parent.instantiate(&leaf, "leaf_inst", None);
+        parent.instantiate(&leaf, Some("leaf_inst"), None);
         parent.validate(); // Should panic
     }
 
@@ -612,7 +613,7 @@ endmodule
         let in_port1 = parent.add_port("in1", IO::Input(1));
         let in_port2 = parent.add_port("in2", IO::Input(1));
 
-        let inst = parent.instantiate(&leaf, "leaf_inst", None);
+        let inst = parent.instantiate(&leaf, Some("leaf_inst"), None);
 
         inst.get_port("in").connect(&in_port1);
         inst.get_port("in").connect(&in_port2);
@@ -644,7 +645,7 @@ endmodule
         leaf.add_port("out", IO::Output(1));
 
         let parent = ModDef::new("ParentMod");
-        parent.instantiate(&leaf, "leaf_inst", None);
+        parent.instantiate(&leaf, Some("leaf_inst"), None);
         parent.validate(); // Should panic
     }
 
@@ -655,7 +656,7 @@ endmodule
         leaf.add_port("out", IO::Output(1));
 
         let parent = ModDef::new("ParentMod");
-        let inst = parent.instantiate(&leaf, "leaf_inst", None);
+        let inst = parent.instantiate(&leaf, Some("leaf_inst"), None);
         inst.get_port("out").unused();
         parent.validate(); // Should pass
     }
@@ -678,7 +679,7 @@ endmodule
         leaf.add_port("out", IO::Output(1));
 
         let parent = ModDef::new("ParentMod");
-        let inst = parent.instantiate(&leaf, "leaf_inst", None);
+        let inst = parent.instantiate(&leaf, Some("leaf_inst"), None);
 
         let in_port = parent.add_port("in", IO::Input(1));
         inst.get_port("out").connect(&in_port);
@@ -709,10 +710,10 @@ endmodule
         leaf.add_port("out", IO::Output(1));
 
         let parent1 = ModDef::new("ParentMod1");
-        let inst1 = parent1.instantiate(&leaf, "leaf_inst1", None);
+        let inst1 = parent1.instantiate(&leaf, Some("leaf_inst1"), None);
 
         let parent2 = ModDef::new("ParentMod2");
-        let inst2 = parent2.instantiate(&leaf, "leaf_inst2", None);
+        let inst2 = parent2.instantiate(&leaf, Some("leaf_inst2"), None);
 
         inst1.get_port("out").connect(&inst2.get_port("in"));
 
@@ -738,7 +739,7 @@ endmodule
         leaf.add_port("out", IO::Output(1));
 
         let parent = ModDef::new("ParentMod");
-        let inst = parent.instantiate(&leaf, "leaf_inst", None);
+        let inst = parent.instantiate(&leaf, Some("leaf_inst"), None);
 
         let parent_in = parent.add_port("in", IO::Input(1));
         let parent_out = parent.add_port("out", IO::Output(1));
@@ -756,7 +757,7 @@ endmodule
         leaf.add_port("in", IO::Input(1));
 
         let parent = ModDef::new("ParentMod");
-        let inst = parent.instantiate(&leaf, "leaf_inst", None);
+        let inst = parent.instantiate(&leaf, Some("leaf_inst"), None);
 
         inst.get_port("in").tieoff(0);
 
@@ -792,7 +793,7 @@ endmodule
         leaf.add_port("out", IO::Output(1));
 
         let parent = ModDef::new("ParentMod");
-        let inst = parent.instantiate(&leaf, "leaf_inst", None);
+        let inst = parent.instantiate(&leaf, Some("leaf_inst"), None);
 
         inst.get_port("out").tieoff(0);
 
@@ -879,17 +880,17 @@ endmodule
 
         let top = ModDef::new("Top");
 
-        top.instantiate(&w16, "inst0", None)
+        top.instantiate(&w16, Some("inst0"), None)
             .get_port("data")
             .unused();
-        top.instantiate(&w16, "inst1", None)
+        top.instantiate(&w16, Some("inst1"), None)
             .get_port("data")
             .unused();
 
-        top.instantiate(&w32, "inst2", None)
+        top.instantiate(&w32, Some("inst2"), None)
             .get_port("data")
             .unused();
-        top.instantiate(&w32, "inst3", None)
+        top.instantiate(&w32, Some("inst3"), None)
             .get_port("data")
             .unused();
 
@@ -958,7 +959,7 @@ endmodule
         top_module.add_port("top_ready", IO::Input(1));
         let top_intf = top_module.def_intf_from_prefix("top_intf", "top_");
 
-        let a_inst = top_module.instantiate(&module_a, "inst_a", None);
+        let a_inst = top_module.instantiate(&module_a, Some("inst_a"), None);
 
         let a_intf = a_inst.get_intf("a_intf");
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -993,4 +993,70 @@ endmodule
 "
         );
     }
+
+    #[test]
+    fn test_instantiate_array() {
+        let child_moddef = ModDef::new("child");
+        let child_data_out = child_moddef.add_port("data_out", IO::Output(1));
+        child_data_out.tieoff(0);
+
+        let parent_moddef = ModDef::new("parent");
+        let parent_data_out = parent_moddef.add_port("parent_data_out", IO::Output(6));
+
+        let instances = parent_moddef.instantiate_array(&child_moddef, &[2, 3], None);
+
+        // Connect the data_out port of each child instance to a bit in the parent_data_out port
+        for (idx, inst) in instances.iter().enumerate() {
+            inst.get_port("data_out")
+                .connect(&parent_data_out.slice(idx, idx));
+        }
+
+        let expected_verilog = "\
+module child(
+  output wire data_out
+);
+  assign data_out = 1'd0;
+endmodule
+module parent(
+  output wire [5:0] parent_data_out
+);
+  wire child_inst_0_0_data_out;
+  wire child_inst_0_1_data_out;
+  wire child_inst_0_2_data_out;
+  wire child_inst_1_0_data_out;
+  wire child_inst_1_1_data_out;
+  wire child_inst_1_2_data_out;
+  child child_inst_0_0 (
+    .data_out(child_inst_0_0_data_out)
+  );
+  child child_inst_0_1 (
+    .data_out(child_inst_0_1_data_out)
+  );
+  child child_inst_0_2 (
+    .data_out(child_inst_0_2_data_out)
+  );
+  child child_inst_1_0 (
+    .data_out(child_inst_1_0_data_out)
+  );
+  child child_inst_1_1 (
+    .data_out(child_inst_1_1_data_out)
+  );
+  child child_inst_1_2 (
+    .data_out(child_inst_1_2_data_out)
+  );
+  assign parent_data_out[0:0] = child_inst_0_0_data_out;
+  assign parent_data_out[1:1] = child_inst_0_1_data_out;
+  assign parent_data_out[2:2] = child_inst_0_2_data_out;
+  assign parent_data_out[3:3] = child_inst_1_0_data_out;
+  assign parent_data_out[4:4] = child_inst_1_1_data_out;
+  assign parent_data_out[5:5] = child_inst_1_2_data_out;
+endmodule
+    ";
+
+        // Emit the Verilog code from the parent module
+        let emitted_verilog = parent_moddef.emit(true);
+
+        // Assert that the emitted Verilog matches the expected Verilog
+        assert_eq!(emitted_verilog.trim(), expected_verilog.trim());
+    }
 }


### PR DESCRIPTION
Makes the instance name optional in `instantiate()`, defaulting to the module name with `_inst` appended.

Also adds a method `instantiate_array` that can generate a multidimensional array of instances.