### PR TITLE
Add crossover() method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,6 +1492,27 @@ impl Intf {
         }
     }
 
+    pub fn crossover(&self, other: &Intf) {
+        let self_ports = self.get_ports();
+        assert_eq!(self_ports.len(), 2, "Interface must have exactly two functions.");
+
+        let other_ports = other.get_ports();
+        assert_eq!(other_ports.len(), 2, "Other interface must have exactly two functions.");
+
+        let mut self_keys: Vec<_> = self_ports.keys().collect();
+        self_keys.sort();
+
+        let mut other_keys: Vec<_> = other_ports.keys().collect();
+        other_keys.sort();
+
+        if self_keys != other_keys {
+            panic!("Interface functions must be the same.");
+        }
+
+        self_ports.get(self_keys[0].as_str()).unwrap().connect(other_ports.get(other_keys[1].as_str()).unwrap());
+        self_ports.get(self_keys[1].as_str()).unwrap().connect(other_ports.get(other_keys[0].as_str()).unwrap());
+    }
+
     pub fn tieoff<T: Into<BigInt> + Clone>(&self, value: T) {
         for (_, port) in self.get_ports() {
             match port {


### PR DESCRIPTION
Small method that makes it easier to connect two-port interfaces. May be expanded in the future.