### PR TITLE
Fix bug in exporting a subdivided interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1767,10 +1767,7 @@ impl Intf {
                 for (func_name, port_slice) in self.get_port_slices() {
                     let mod_def_port_name = format!("{}{}", prefix, func_name);
                     port_slice.export_as(&mod_def_port_name);
-                    mapping.insert(
-                        func_name,
-                        (mod_def_port_name, port_slice.msb, port_slice.lsb),
-                    );
+                    mapping.insert(func_name, (mod_def_port_name, port_slice.width() - 1, 0));
                 }
                 ModDef {
                     core: self.get_mod_def_core(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1477,4 +1477,116 @@ endmodule
 "
         );
     }
+
+    #[test]
+    fn test_intf_subdivide_export() {
+        let module_a_verilog = "
+      module ModuleA (
+          output [15:0] a_data_tx,
+          output [1:0] a_valid_tx,
+          input [15:0] a_data_rx,
+          input [1:0] a_valid_rx
+      );
+      endmodule
+      ";
+
+        let module_a = ModDef::from_verilog("ModuleA", module_a_verilog, true, false);
+        let a_intf = module_a.def_intf_from_prefix("a", "a_");
+        a_intf.subdivide(2);
+
+        let wrapper = ModDef::new("Wrapper");
+        let a = wrapper.instantiate(&module_a, None, None);
+        a.get_intf("a_0").export_with_prefix("lower", "lower_");
+        a.get_intf("a_1").export_with_prefix("upper", "upper_");
+
+        let top_module = ModDef::new("TopModule");
+        let w0 = top_module.instantiate(&wrapper, Some("w0"), None);
+        let w1 = top_module.instantiate(&wrapper, Some("w1"), None);
+
+        w0.get_intf("lower")
+            .crossover(&w1.get_intf("lower"), "(.*)_rx$", "(.*)_tx$");
+        w0.get_intf("upper")
+            .crossover(&w1.get_intf("upper"), "(.*)_rx$", "(.*)_tx$");
+
+        assert_eq!(
+            top_module.emit(true),
+            "\
+module Wrapper(
+  output wire [7:0] lower_data_tx,
+  output wire lower_valid_tx,
+  input wire [7:0] lower_data_rx,
+  input wire lower_valid_rx,
+  output wire [7:0] upper_data_tx,
+  output wire upper_valid_tx,
+  input wire [7:0] upper_data_rx,
+  input wire upper_valid_rx
+);
+  wire [15:0] ModuleA_i_a_data_tx;
+  wire [1:0] ModuleA_i_a_valid_tx;
+  wire [15:0] ModuleA_i_a_data_rx;
+  wire [1:0] ModuleA_i_a_valid_rx;
+  ModuleA ModuleA_i (
+    .a_data_tx(ModuleA_i_a_data_tx),
+    .a_valid_tx(ModuleA_i_a_valid_tx),
+    .a_data_rx(ModuleA_i_a_data_rx),
+    .a_valid_rx(ModuleA_i_a_valid_rx)
+  );
+  assign lower_data_tx[7:0] = ModuleA_i_a_data_tx[7:0];
+  assign lower_valid_tx = ModuleA_i_a_valid_tx[0:0];
+  assign ModuleA_i_a_data_rx[7:0] = lower_data_rx[7:0];
+  assign ModuleA_i_a_valid_rx[0:0] = lower_valid_rx;
+  assign upper_data_tx[7:0] = ModuleA_i_a_data_tx[15:8];
+  assign upper_valid_tx = ModuleA_i_a_valid_tx[1:1];
+  assign ModuleA_i_a_data_rx[15:8] = upper_data_rx[7:0];
+  assign ModuleA_i_a_valid_rx[1:1] = upper_valid_rx;
+endmodule
+module TopModule;
+  wire [7:0] w0_lower_data_tx;
+  wire w0_lower_valid_tx;
+  wire [7:0] w0_lower_data_rx;
+  wire w0_lower_valid_rx;
+  wire [7:0] w0_upper_data_tx;
+  wire w0_upper_valid_tx;
+  wire [7:0] w0_upper_data_rx;
+  wire w0_upper_valid_rx;
+  wire [7:0] w1_lower_data_tx;
+  wire w1_lower_valid_tx;
+  wire [7:0] w1_lower_data_rx;
+  wire w1_lower_valid_rx;
+  wire [7:0] w1_upper_data_tx;
+  wire w1_upper_valid_tx;
+  wire [7:0] w1_upper_data_rx;
+  wire w1_upper_valid_rx;
+  Wrapper w0 (
+    .lower_data_tx(w0_lower_data_tx),
+    .lower_valid_tx(w0_lower_valid_tx),
+    .lower_data_rx(w0_lower_data_rx),
+    .lower_valid_rx(w0_lower_valid_rx),
+    .upper_data_tx(w0_upper_data_tx),
+    .upper_valid_tx(w0_upper_valid_tx),
+    .upper_data_rx(w0_upper_data_rx),
+    .upper_valid_rx(w0_upper_valid_rx)
+  );
+  Wrapper w1 (
+    .lower_data_tx(w1_lower_data_tx),
+    .lower_valid_tx(w1_lower_valid_tx),
+    .lower_data_rx(w1_lower_data_rx),
+    .lower_valid_rx(w1_lower_valid_rx),
+    .upper_data_tx(w1_upper_data_tx),
+    .upper_valid_tx(w1_upper_valid_tx),
+    .upper_data_rx(w1_upper_data_rx),
+    .upper_valid_rx(w1_upper_valid_rx)
+  );
+  assign w0_lower_data_rx[7:0] = w1_lower_data_tx[7:0];
+  assign w0_lower_valid_rx = w1_lower_valid_tx;
+  assign w1_lower_data_rx[7:0] = w0_lower_data_tx[7:0];
+  assign w1_lower_valid_rx = w0_lower_valid_tx;
+  assign w0_upper_data_rx[7:0] = w1_upper_data_tx[7:0];
+  assign w0_upper_valid_rx = w1_upper_valid_tx;
+  assign w1_upper_data_rx[7:0] = w0_upper_data_tx[7:0];
+  assign w1_upper_valid_rx = w0_upper_valid_tx;
+endmodule
+"
+        );
+    }
 }


### PR DESCRIPTION
There was a bug where exporting a subdivided interface resulted in an error when the exported port was used later. The problem had to do with subdivided sections of buses `msb:lsb` with a non-zero `lsb` - that non-zero offset was incorrectly being used as the starting point for the exported port slice. This is problematic because the port has indices running from `0` to `msb-lsb+1`, not `lsb` to `msb`. As a result, when the port slice is used later, the check that `msb` is less than the port width fails.

The fix for this bug is one line, however I am also adding a test to check for this in the future, hence the ~100 LOC PR.