### PR TITLE
Usability updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"


### PR DESCRIPTION
New function for `Port`/`PortSlice`:
* `export()`: Export a signal while keeping the same port name.

New functions for `Intf`:
* `export()`: Export a signal while keeping signals the same, under an interface with the same name.
* `export_with_name_underscore(name)`: Shorthand for `export_with_prefix("<name>", "<name>_")`

New functions for `ModDef`:
* `def_intf_from_name_underscore(name)`: Shorthand for `def_intf_from_prefix("<name>", "<name>_")` 
* `def_intf_from_prefixes(name, prefixes, strip_prefix)`: Gather multiple prefixes under a single interface with one command. `strip_prefix` controls whether the matching prefix should be stripped when inferring function names.

Updated `crossover` function: regex expression can now contain zero or more capture groups, which are joined with `_` to infer functions.

`HashMap` usage in validation replaced with `IndexMap` for deterministic results - makes debugging easier.

Other: most functions that accepted `&str` are now more flexible and will directly accept `String`. This means that you can do things like `export_as(format!(...))` instead of `export_as(&format!(...))` or `export_as(format!(...).as_str())`. (All three forms will work, though, so this is backwards-compatible)