### PR TITLE
Regex interface definition, funnel concept, copy/flip interface operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"


### PR DESCRIPTION
PR contains a variety of experimental features to be refined (including documentation) in subsequent releases:
* Defining interfaces with search/replace regexes
* "Funnel" concept for feeding one or more interfaces through generic flat ports.
* Copy and flip operations for creating interfaces on one module definition that match or complement an existing interface. Like `export`, except no connectivity is established.