### PR TITLE
Add stub_recursive and related methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2560,4 +2560,49 @@ endmodule
 "
         );
     }
+
+    #[test]
+    fn test_stub_recursive() {
+        let a_def = ModDef::new("a");
+        let b_def = ModDef::new("b");
+        let c_def = ModDef::new("skip_c");
+        let d_def = ModDef::new("skip_d");
+        let e_def = ModDef::new("e");
+        let f_def = ModDef::new("f");
+        let g_def = ModDef::new("g");
+
+        a_def.instantiate(&b_def, None, None);
+        a_def.instantiate(&c_def, None, None);
+        b_def.instantiate(&d_def, None, None);
+        c_def.instantiate(&e_def, None, None);
+        d_def.instantiate(&f_def, None, None);
+        e_def.instantiate(&g_def, None, None);
+
+        a_def.stub_recursive("^skip_(.*)$");
+
+        assert_eq!(
+            a_def.emit(true),
+            "\
+module skip_d;
+
+endmodule
+module b;
+  skip_d skip_d_i (
+    
+  );
+endmodule
+module skip_c;
+
+endmodule
+module a;
+  b b_i (
+    
+  );
+  skip_c skip_c_i (
+    
+  );
+endmodule
+"
+        );
+    }
 }


### PR DESCRIPTION
This PR adds a method that applies `Usage::EmitStubAndStop` to instances within a `ModDef` whose names match a regular expression, descending recursively into their instances. Also as part of this PR, several access methods are added that make it possible to implement this sort of algorithm in TopStitch user code.