### PR TITLE
Temporary support for inout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "indexmap",
  "itertools",
@@ -743,18 +743,18 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.30"
+version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd70e7db29c4bcac86ad43d59cc887569c5764e24562fc8ab9642bb621b1b436"
+checksum = "e8d071a3eb6cbf63a900105262c9ae1d390cd8a7a91750d5b65577d03f85d574"
 dependencies = [
  "xlsynth-sys",
 ]
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.30"
+version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c4140ab13e727f18d5701cf929ce5d394839d0a562e6b80f5ee5ff347aa1c"
+checksum = "b586d1664d7b9997082471842b060dcbceeb7d8558b49e8dadec699d46c5b8a3"
 dependencies = [
  "curl",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/topstitch"
 [dependencies]
 num-bigint = "0.4.3"
 indexmap = "2.5.0"
-xlsynth = "0.0.30"
+xlsynth = "0.0.42"
 slang-rs = "0.11.0"
 itertools = "0.10"
 regex = "1.11.0"

--- a/src/inout.rs
+++ b/src/inout.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO(sherbst) 11/19/24: Replace with a VAST API call.
+
+pub const INOUT_MARKER: &str = "_INOUT_RENAME";
+
+pub fn rename_inout(text: String) -> String {
+    let mut lines: Vec<String> = text.split('\n').map(|s| s.to_string()).collect();
+    for line in &mut lines {
+        let inout_rename = line.contains(INOUT_MARKER);
+        if !inout_rename {
+            continue;
+        }
+
+        let input_port = line.trim_start().starts_with("input");
+
+        if input_port {
+            *line = line.replacen("input", "inout", 1);
+        }
+
+        *line = line.replace(INOUT_MARKER, "");
+    }
+    lines.join("\n")
+}


### PR DESCRIPTION
Adds temporary support for `inout` ports by post-processing the generated netlist. `inout` ports are emitted with direction `input` by VAST, and they are given a special suffix, `_RENAME_INOUT`. Post-processing removes this suffix and changes `input` to `inout`. This will hopefully be replaced soon with a VAST API call.

The other key change required was to support direct connections from module definitions to module instances, without using an intermediate `assign`. This is important because `assign` cannot be used with `inout` in synthesizable code.

`inout` connections are not yet validated - this will be the subject of a future PR.