### PR TITLE
Use incdirs if provided when re-parsing modules given non-default parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,7 @@ pub struct ModInst {
 
 struct VerilogImport {
     sources: Vec<String>,
+    incdirs: Vec<String>,
     skip_unsupported: bool,
     ignore_unknown_modules: bool,
 }
@@ -612,6 +613,7 @@ impl ModDef {
                 tieoffs: Vec::new(),
                 verilog_import: Some(VerilogImport {
                     sources: cfg.sources.iter().map(|s| s.to_string()).collect(),
+                    incdirs: cfg.incdirs.iter().map(|s| s.to_string()).collect(),
                     skip_unsupported,
                     ignore_unknown_modules: cfg.ignore_unknown_modules,
                 }),
@@ -1501,8 +1503,18 @@ impl ModDef {
             .map(|s| s.as_str())
             .collect();
 
+        let incdirs: Vec<&str> = core
+            .verilog_import
+            .as_ref()
+            .unwrap()
+            .incdirs
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+
         let cfg = SlangConfig {
             sources: sources.as_slice(),
+            incdirs: incdirs.as_slice(),
             parameters: &parameters_with_string_values
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))


### PR DESCRIPTION
Previously, `incdirs` were not "remembered" when `parameterize()` was caused, which could cause parsing errors at that point.