### PR TITLE
Cast for non-arrayed enum input ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/enum_type.rs
+++ b/src/enum_type.rs
@@ -1,0 +1,131 @@
+use indexmap::IndexMap;
+use regex::Regex;
+
+pub fn remap_enum_types(
+    text: String,
+    enum_remapping: &IndexMap<String, IndexMap<String, IndexMap<String, String>>>,
+) -> String {
+    let mut lines: Vec<String> = text.split('\n').map(|s| s.to_string()).collect();
+
+    let regex = Regex::new(r"\.(\w+)\(([\w\[\]:]+)\)").unwrap();
+
+    let mut current_mod_def_name: Option<String> = None;
+    let mut current_mod_inst_name: Option<String> = None;
+
+    for line in lines.iter_mut() {
+        let trimmed_line = line.trim();
+        if trimmed_line.starts_with("endmodule") {
+            current_mod_def_name = None;
+            current_mod_inst_name = None;
+        } else if trimmed_line.starts_with("module") {
+            if let Some(name) = trimmed_line.split_whitespace().nth(1) {
+                let def_name = name.split('(').next().unwrap().to_string();
+                current_mod_def_name = Some(def_name);
+            }
+            current_mod_inst_name = None;
+        } else if let Some(ref def_name) = current_mod_def_name {
+            if let Some(map_of_insts) = enum_remapping.get(def_name) {
+                if trimmed_line.ends_with(");") {
+                    current_mod_inst_name = None;
+                } else if trimmed_line.ends_with("(") {
+                    if let Some(inst_name) = trimmed_line.split_whitespace().nth(1) {
+                        current_mod_inst_name = Some(inst_name.to_string());
+                    }
+                } else if let Some(ref inst_name) = current_mod_inst_name {
+                    if let Some(map_of_ports) = map_of_insts.get(inst_name) {
+                        if trimmed_line.starts_with(".") {
+                            let mut tokens = trimmed_line.split('(');
+                            let port_name =
+                                tokens.next().unwrap().trim_start_matches('.').to_string();
+                            if let Some(enum_name) = map_of_ports.get(&port_name) {
+                                *line = regex
+                                    .replace(line, |caps: &regex::Captures| {
+                                        format!(".{}({}'({}))", &caps[1], enum_name, &caps[2])
+                                    })
+                                    .to_string();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    #[test]
+    fn test_remap_enum_types() {
+        let mut enum_remapping = IndexMap::new();
+
+        enum_remapping.insert("ModA".to_string(), IndexMap::new());
+        enum_remapping["ModA"].insert("instA".to_string(), IndexMap::new());
+        enum_remapping["ModA"]["instA"].insert("portA".to_string(), "EnumTypeA".to_string());
+
+        enum_remapping.insert("ModB".to_string(), IndexMap::new());
+        enum_remapping["ModB"].insert("instB".to_string(), IndexMap::new());
+        enum_remapping["ModB"]["instB"].insert("portB".to_string(), "EnumTypeB".to_string());
+
+        let input_verilog = "
+module ModA (
+    input wire [1:0] portA,
+    output wire [1:0] portB
+);
+    wire [1:0] signalA;
+    wire [1:0] signalB;
+    ModB instA (
+        .portA(signalA[1:0]),
+        .portB(signalB[1:0])
+    );
+endmodule
+
+module ModB (
+    input wire [1:0] portA,
+    output wire [1:0] portB
+);
+    wire [1:0] signalC;
+    wire [1:0] signalD;
+    ModC instB (
+        .portA(signalC),
+        .portB(signalD)
+    );
+endmodule
+"
+        .to_string();
+
+        let expected_output = "
+module ModA (
+    input wire [1:0] portA,
+    output wire [1:0] portB
+);
+    wire [1:0] signalA;
+    wire [1:0] signalB;
+    ModB instA (
+        .portA(EnumTypeA'(signalA[1:0])),
+        .portB(signalB[1:0])
+    );
+endmodule
+
+module ModB (
+    input wire [1:0] portA,
+    output wire [1:0] portB
+);
+    wire [1:0] signalC;
+    wire [1:0] signalD;
+    ModC instB (
+        .portA(signalC),
+        .portB(EnumTypeB'(signalD))
+    );
+endmodule
+"
+        .to_string();
+
+        let result = remap_enum_types(input_verilog, &enum_remapping);
+        assert_eq!(result, expected_output);
+    }
+}


### PR DESCRIPTION
This PR deals with a specific LRM issue, which is that it is not legal to connect a non-arrayed enum input port directly to a flat bus. Instead, a cast must be used. This is not necessary for output ports or arrayed enum inputs.

This fix is temporary in two senses:
1. It is implemented with text parsing outside of VAST (would like to use VAST instead)
2. This problem should go away altogether when TopStitch has more direct support of enums, since there will no longer be a need to directly connect enums to flat buses.