### PR TITLE
Fix issue with enum ports and parameterization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"


### PR DESCRIPTION
This PR fixes a bug where enum-related casting was not applied properly to modules with parameterization. Casting was not used in the wrapper for parameterization, where casting was needed, while casting was used in modules that instantiated the wrapper, where it should not have been used.