### PR TITLE
Implement whole-port tieoffs directly in instantiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"


### PR DESCRIPTION
In other words, rather than connecting a module port to a wire, and then assigning a constant to that wire, connect the module port to a constant.

Only applies to tieoffs on module instances.