### PR TITLE
Connect `rst` and `out_stages` on `br_delay_nr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "indexmap",
  "itertools",
@@ -743,18 +790,20 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.42"
+version = "0.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d071a3eb6cbf63a900105262c9ae1d390cd8a7a91750d5b65577d03f85d574"
+checksum = "cc7a6596bdf520446740050d796c239439d2b31d85b0832643dc02d38e3a79d3"
 dependencies = [
+ "cargo_metadata",
+ "log",
  "xlsynth-sys",
 ]
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.42"
+version = "0.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b586d1664d7b9997082471842b060dcbceeb7d8558b49e8dadec699d46c5b8a3"
+checksum = "7c3c83eb5b5a799a7a599003af1b6377b30999bc8ff2365b6a5d95f672e15bca"
 dependencies = [
  "curl",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/topstitch"
 [dependencies]
 num-bigint = "0.4.3"
 indexmap = "2.5.0"
-xlsynth = "0.0.42"
+xlsynth = "0.0.51"
 slang-rs = "0.12.0"
 itertools = "0.10"
 regex = "1.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1215,10 +1215,10 @@ impl ModDef {
                     }
 
                     if concat_entries.len() == 1 {
-                        connection_expressions.push(concat_entries.remove(0));
+                        connection_expressions.push(Some(concat_entries.remove(0)));
                     } else {
                         let slice_references: Vec<&Expr> = concat_entries.iter().collect();
-                        connection_expressions.push(file.make_concat(&slice_references));
+                        connection_expressions.push(Some(file.make_concat(&slice_references)));
                     }
                 } else if self
                     .core
@@ -1232,10 +1232,10 @@ impl ModDef {
                     let value_expr = file
                         .make_literal(&literal_str, &xlsynth::ir_value::IrFormatPreference::Hex)
                         .unwrap();
-                    connection_expressions.push(value_expr);
+                    connection_expressions.push(Some(value_expr));
                 } else {
                     let net_name = format!("{}_{}", inst_name, port_name);
-                    connection_expressions.push(nets.get(&net_name).unwrap().to_expr());
+                    connection_expressions.push(Some(nets.get(&net_name).unwrap().to_expr()));
                 }
             }
 
@@ -1248,7 +1248,10 @@ impl ModDef {
                     .iter()
                     .map(|s| s.as_str())
                     .collect::<Vec<&str>>(),
-                &connection_expressions.iter().collect::<Vec<_>>(),
+                &connection_expressions
+                    .iter()
+                    .map(|o| o.as_ref())
+                    .collect::<Vec<_>>(),
             );
             module.add_member_instantiation(instantiation);
         }
@@ -1713,7 +1716,7 @@ impl ModDef {
                         ),
                     };
                     connection_port_names.push(name.clone());
-                    connection_expressions.push(logic_expr.to_expr());
+                    connection_expressions.push(Some(logic_expr.to_expr()));
                     connection_logic_refs.push(logic_expr);
                 }
                 Err(e) => {
@@ -1753,7 +1756,10 @@ impl ModDef {
                     .iter()
                     .map(|s| s.as_str())
                     .collect::<Vec<&str>>(),
-                &connection_expressions.iter().collect::<Vec<_>>(),
+                &connection_expressions
+                    .iter()
+                    .map(|o| o.as_ref())
+                    .collect::<Vec<_>>(),
             ),
         );
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -26,13 +26,25 @@ pub fn add_pipeline(params: PipelineDetails) {
         .make_literal(&num_stages_str, &xlsynth::ir_value::IrFormatPreference::Hex)
         .unwrap();
 
+    let rst_str = format!("bits[{}]:{}", 1, 0);
+    let rst_expr = params
+        .file
+        .make_literal(&rst_str, &xlsynth::ir_value::IrFormatPreference::Hex)
+        .unwrap();
+
     let instantiation = params.file.make_instantiation(
         "br_delay_nr",
         params.inst_name,
         &["Width", "NumStages"],
         &[&width_expr, &num_stages_expr],
-        &["clk", "in", "out"],
-        &[params.clk, params.pipe_in, params.pipe_out],
+        &["clk", "in", "out", "rst", "out_stages"],
+        &[
+            Some(params.clk),
+            Some(params.pipe_in),
+            Some(params.pipe_out),
+            Some(&rst_expr),
+            None,
+        ],
     );
     params.module.add_member_instantiation(instantiation);
 }
@@ -78,7 +90,9 @@ module test;
   ) br_delay_nr_i (
     .clk(clk),
     .in(pipe_in),
-    .out(pipe_out)
+    .out(pipe_out),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 "

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2924,7 +2924,9 @@ module c(
   ) pipeline_conn_1 (
     .clk(clk_existing),
     .in(a_i_out[170:0]),
-    .out(b_i_in[170:0])
+    .out(b_i_in[170:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_00ef),
@@ -2932,7 +2934,9 @@ module c(
   ) pipeline_conn_3 (
     .clk(clk_new),
     .in(b_i_out[238:0]),
-    .out(a_i_in[238:0])
+    .out(a_i_in[238:0]),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 "
@@ -3004,7 +3008,9 @@ module TopModule(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(inst_a_a_data[31:0]),
-    .out(inst_b_b_data[31:0])
+    .out(inst_b_b_data[31:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0001),
@@ -3012,7 +3018,9 @@ module TopModule(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(inst_a_a_valid),
-    .out(inst_b_b_valid)
+    .out(inst_b_b_valid),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 "
@@ -3085,7 +3093,9 @@ module TopModule(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(inst_a_a_tx),
-    .out(inst_b_b_rx)
+    .out(inst_b_b_rx),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0001),
@@ -3093,7 +3103,9 @@ module TopModule(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(inst_b_b_tx),
-    .out(inst_a_a_rx)
+    .out(inst_a_a_rx),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 "
@@ -3112,6 +3124,7 @@ endmodule
                 depth: 0xab,
             },
         );
+
         assert_eq!(
             mod_def.emit(true),
             "\
@@ -3126,7 +3139,9 @@ module TestModule(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(input_signal[7:0]),
-    .out(output_signal[7:0])
+    .out(output_signal[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 "
@@ -3181,7 +3196,6 @@ endmodule
             .get_intf("c")
             .crossover(&b_inst.get_intf("ft_right"), "(.*)_in", "(.*)_out");
 
-        println!("{}", top_module.emit(true));
         assert_eq!(
             top_module.emit(true),
             "\
@@ -3198,7 +3212,9 @@ module ModuleB(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(ft_left_data_out[7:0]),
-    .out(ft_right_data_out[7:0])
+    .out(ft_right_data_out[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0001),
@@ -3206,7 +3222,9 @@ module ModuleB(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(ft_left_valid_out),
-    .out(ft_right_valid_out)
+    .out(ft_right_valid_out),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 module TopModule;
@@ -3310,7 +3328,9 @@ module ModuleB(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(ft_flipped_a_data[7:0]),
-    .out(ft_original_a_data[7:0])
+    .out(ft_original_a_data[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0001),
@@ -3318,7 +3338,9 @@ module ModuleB(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(ft_flipped_a_valid),
-    .out(ft_original_a_valid)
+    .out(ft_original_a_valid),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 module ModuleC(
@@ -3343,7 +3365,9 @@ module ModuleD(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(ft_flipped_a_data[7:0]),
-    .out(ft_original_a_data[7:0])
+    .out(ft_original_a_data[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0001),
@@ -3351,7 +3375,9 @@ module ModuleD(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(ft_flipped_a_valid),
-    .out(ft_original_a_valid)
+    .out(ft_original_a_valid),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 module TopModule;
@@ -3481,7 +3507,9 @@ module ModuleB(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(ft_flipped_a_tx[7:0]),
-    .out(ft_original_e_tx[7:0])
+    .out(ft_original_e_tx[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0008),
@@ -3489,7 +3517,9 @@ module ModuleB(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(ft_original_e_rx[7:0]),
-    .out(ft_flipped_a_rx[7:0])
+    .out(ft_flipped_a_rx[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 module ModuleC(
@@ -3514,7 +3544,9 @@ module ModuleD(
   ) pipeline_conn_0 (
     .clk(clk),
     .in(ft_flipped_a_tx[7:0]),
-    .out(ft_original_e_tx[7:0])
+    .out(ft_original_e_tx[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
   br_delay_nr #(
     .Width(32'h0000_0008),
@@ -3522,7 +3554,9 @@ module ModuleD(
   ) pipeline_conn_1 (
     .clk(clk),
     .in(ft_original_e_rx[7:0]),
-    .out(ft_flipped_a_rx[7:0])
+    .out(ft_flipped_a_rx[7:0]),
+    .rst(1'h0),
+    .out_stages()
   );
 endmodule
 module TopModule;


### PR DESCRIPTION
Even though the `rst` input isn't connected within `br_delay_nr`, some tools may complain about it not being connected. For a similar reason `out_stages` is marked as unconnected with `.out_stages()`.