### PR TITLE
`InOut` updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2668,6 +2668,11 @@ endmodule
         a_inst.get_port("f").slice(7, 0).export_as("f");
         a_inst.get_port("g").slice(11, 8).export_as("g");
 
+        a_inst.get_port("e").slice(7, 0).unused();
+        a_inst.get_port("f").slice(15, 8).unused();
+        a_inst.get_port("g").slice(15, 12).unused();
+        a_inst.get_port("g").slice(7, 0).unused();
+
         assert_eq!(
             top.emit(true),
             "\
@@ -3598,5 +3603,148 @@ module TopModule;
 endmodule
 "
         );
+    }
+
+    #[test]
+    fn test_inout_modinst() {
+        let a_verilog = "\
+module A(
+  inout a0,
+  inout a1,
+  inout b,
+  inout [1:0] c,
+  inout d,
+  input e
+);
+endmodule";
+        let b_verilog = "\
+module B(
+  inout [1:0] a,
+  inout b,
+  inout [1:0] c,
+  output d,
+  inout e
+);
+endmodule";
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
+
+        // Define module C
+        let c_mod_def: ModDef = ModDef::new("C");
+
+        // Instantiate A and B in C
+        let a_inst = c_mod_def.instantiate(&a_mod_def, Some("inst_a"), None);
+        let b_inst = c_mod_def.instantiate(&b_mod_def, Some("inst_b"), None);
+
+        b_inst
+            .get_port("a")
+            .slice(0, 0)
+            .connect(&a_inst.get_port("a0"));
+        a_inst
+            .get_port("a1")
+            .connect(&b_inst.get_port("a").slice(1, 1));
+        a_inst.get_port("b").connect(&b_inst.get_port("b"));
+        b_inst.get_port("c").connect(&a_inst.get_port("c"));
+        b_inst.get_port("d").connect(&a_inst.get_port("d"));
+        a_inst.get_port("e").connect(&b_inst.get_port("e"));
+
+        assert_eq!(
+            c_mod_def.emit(true),
+            "\
+module C;
+  wire inst_b_a_0_0_inst_a_a0_0_0;
+  wire inst_a_a1_0_0_inst_b_a_1_1;
+  wire inst_a_b_0_0_inst_b_b_0_0;
+  wire [1:0] inst_b_c_1_0_inst_a_c_1_0;
+  wire inst_b_d_0_0_inst_a_d_0_0;
+  wire inst_a_e_0_0_inst_b_e_0_0;
+  A inst_a (
+    .a0(inst_b_a_0_0_inst_a_a0_0_0),
+    .a1(inst_a_a1_0_0_inst_b_a_1_1),
+    .b(inst_a_b_0_0_inst_b_b_0_0),
+    .c(inst_b_c_1_0_inst_a_c_1_0),
+    .d(inst_b_d_0_0_inst_a_d_0_0),
+    .e(inst_a_e_0_0_inst_b_e_0_0)
+  );
+  B inst_b (
+    .a({inst_a_a1_0_0_inst_b_a_1_1, inst_b_a_0_0_inst_a_a0_0_0}),
+    .b(inst_a_b_0_0_inst_b_b_0_0),
+    .c(inst_b_c_1_0_inst_a_c_1_0),
+    .d(inst_b_d_0_0_inst_a_d_0_0),
+    .e(inst_a_e_0_0_inst_b_e_0_0)
+  );
+endmodule
+"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "B.inst_a.a is not fully used")]
+    fn test_inout_unused_0() {
+        let a_verilog = "\
+module A(
+  inout a
+);
+endmodule";
+
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def: ModDef = ModDef::new("B");
+
+        b_mod_def.instantiate(&a_mod_def, Some("inst_a"), None);
+
+        b_mod_def.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "B.inst_a.a is not fully used")]
+    fn test_inout_unused_1() {
+        let a_verilog = "\
+module A(
+  inout [1:0] a
+);
+endmodule";
+
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+
+        let b_mod_def: ModDef = ModDef::new("B");
+        b_mod_def.add_port("b", IO::InOut(1));
+
+        let a_inst = b_mod_def.instantiate(&a_mod_def, Some("inst_a"), None);
+        a_inst
+            .get_port("a")
+            .slice(0, 0)
+            .connect(&b_mod_def.get_port("b"));
+
+        b_mod_def.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "A.a is not fully used")]
+    fn test_inout_unused_2() {
+        let a_mod_def: ModDef = ModDef::new("A");
+        a_mod_def.add_port("a", IO::InOut(1));
+        a_mod_def.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "B.b is not fully used")]
+    fn test_inout_unused_3() {
+        let a_verilog = "\
+module A(
+  inout a
+);
+endmodule";
+
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+
+        let b_mod_def: ModDef = ModDef::new("B");
+        b_mod_def.add_port("b", IO::InOut(2));
+
+        let a_inst = b_mod_def.instantiate(&a_mod_def, Some("inst_a"), None);
+        a_inst
+            .get_port("a")
+            .connect(&b_mod_def.get_port("b").slice(0, 0));
+
+        b_mod_def.validate();
     }
 }


### PR DESCRIPTION
This PR adds several `InOut`-related features+related tests in a rough fashion, to be cleaned up in a future PR.

* Allow connections between `InOut` ports on modules
* Allow `Input`/`Output` ports to connect to `InOut` ports
* Check for unconnected `InOut` ports (they can now be marked `unused()`)

Note: direct connection (as opposed to assign-based connection) is being developed for `InOut`-related connections and will eventually replace `assign`-based connections in most places. That update is still a little while off, however - will involve updating most tests and consolidating a bunch of logic.