### PR TITLE
Add `connect_to_net()` and remove `set_wire_name()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.37.0"
+version = "0.39.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.38.0"
+version = "0.37.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.38.0"
+version = "0.37.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.37.0"
+version = "0.39.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3820,7 +3820,7 @@ endmodule
         a_inst.get_port("a").tieoff(0);
 
         assert_eq!(
-            top.emit(true),
+            top.emit(false),
             "\
 module TopModule;
   ModuleA ModuleA_i (
@@ -3829,55 +3829,5 @@ module TopModule;
 endmodule
 "
         );
-    }
-
-    #[test]
-    fn test_set_wire_name() {
-        let a_verilog = "\
-module A(
-  output ao
-);
-endmodule";
-        let b_verilog = "\
-module B(
-  input bi
-);
-endmodule";
-        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
-        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
-        let top = ModDef::new("TopModule");
-        let a_inst = top.instantiate(&a_mod_def, None, None);
-        let b_inst = top.instantiate(&b_mod_def, None, None);
-        a_inst.get_port("ao").connect(&b_inst.get_port("bi"));
-        a_inst.get_port("ao").set_wire_name("custom_a");
-        b_inst.get_port("bi").set_wire_name("custom_b");
-        assert_eq!(
-            top.emit(true),
-            "\
-module TopModule;
-  wire custom_a;
-  wire custom_b;
-  A A_i (
-    .ao(custom_a)
-  );
-  B B_i (
-    .bi(custom_b)
-  );
-  assign custom_b = custom_a;
-endmodule
-"
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "set_wire_name can only be called on ports on module instances")]
-    fn test_set_wire_name_on_mod_def() {
-        let a_verilog = "\
-module A(
-  output ao
-);
-endmodule";
-        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
-        a_mod_def.get_port("ao").set_wire_name("custom_a");
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3830,4 +3830,146 @@ endmodule
 "
         );
     }
+  
+    #[test]
+    fn test_connect_to_net() {
+        let a_verilog = "\
+module A(
+  output [7:0] ao
+);
+endmodule";
+        let b_verilog = "\
+module B(
+  input [7:0] bi
+);
+endmodule";
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
+        let top = ModDef::new("TopModule");
+        let a_inst = top.instantiate(&a_mod_def, None, None);
+        let b_inst = top.instantiate(&b_mod_def, None, None);
+        a_inst.get_port("ao").connect_to_net("custom");
+        b_inst.get_port("bi").connect_to_net("custom");
+        assert_eq!(
+            top.emit(true),
+            "\
+module TopModule;
+  wire [7:0] custom;
+  A A_i (
+    .ao(custom)
+  );
+  B B_i (
+    .bi(custom)
+  );
+endmodule
+"
+        );
+    }
+
+    #[test]
+    fn test_connect_to_net_multiple_receivers() {
+        let a_verilog = "\
+module A(
+  output [7:0] ao
+);
+endmodule";
+        let b_verilog = "\
+module B(
+  input [7:0] bi
+);
+endmodule";
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
+        let top = ModDef::new("TopModule");
+        let a_inst = top.instantiate(&a_mod_def, None, None);
+        let b_inst_0 = top.instantiate(&b_mod_def, Some("B_i_0"), None);
+        let b_inst_1 = top.instantiate(&b_mod_def, Some("B_i_1"), None);
+        a_inst.get_port("ao").connect_to_net("custom");
+        b_inst_0.get_port("bi").connect_to_net("custom");
+        b_inst_1.get_port("bi").connect_to_net("custom");
+        assert_eq!(
+            top.emit(true),
+            "\
+module TopModule;
+  wire [7:0] custom;
+  A A_i (
+    .ao(custom)
+  );
+  B B_i_0 (
+    .bi(custom)
+  );
+  B B_i_1 (
+    .bi(custom)
+  );
+endmodule
+"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "TopModule.B_i.bi is not fully driven")]
+    fn test_connect_to_net_undriven_input() {
+        let a_verilog = "\
+module A(
+  output ao
+);
+endmodule";
+        let b_verilog = "\
+module B(
+  input bi
+);
+endmodule";
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
+        let top = ModDef::new("TopModule");
+        let a_inst = top.instantiate(&a_mod_def, None, None);
+        top.instantiate(&b_mod_def, None, None);
+        a_inst.get_port("ao").connect_to_net("custom");
+        top.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "TopModule.A_i.ao is not fully used")]
+    fn test_connect_to_net_unused_output() {
+        let a_verilog = "\
+module A(
+  output ao
+);
+endmodule";
+        let b_verilog = "\
+module B(
+  input bi
+);
+endmodule";
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
+        let top = ModDef::new("TopModule");
+        top.instantiate(&a_mod_def, None, None);
+        let b_inst = top.instantiate(&b_mod_def, None, None);
+        b_inst.get_port("bi").connect_to_net("custom");
+        top.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "Net width mismatch for TopModule.custom: existing width 4, new width 8")]
+    fn test_connect_to_net_width_mismatch() {
+        let a_verilog = "\
+module A(
+  output [3:0] ao
+);
+endmodule";
+        let b_verilog = "\
+module B(
+  input [7:0] bi
+);
+endmodule";
+        let a_mod_def = ModDef::from_verilog("A", a_verilog, true, false);
+        let b_mod_def = ModDef::from_verilog("B", b_verilog, true, false);
+        let top = ModDef::new("TopModule");
+        let a_inst = top.instantiate(&a_mod_def, None, None);
+        let b_inst = top.instantiate(&b_mod_def, None, None);
+        a_inst.get_port("ao").connect_to_net("custom");
+        b_inst.get_port("bi").connect_to_net("custom");
+        top.validate();
+    }
 }


### PR DESCRIPTION
This PR adds an alternative method for making connections, called `connect_to_net()`. Rather than `connect()`-ing inputs and outputs, ports and port slices are connected to nets with a given string name. Although less convenient than existing connection methods, this allows for direct control over wire net names used, and also avoids `assign` statements.

Also as part of this PR, the recently-added `set_wire_name()` method is removed. The reason is that `connect_to_net()` is both more powerful and easier to use.