### PR TITLE
More usability updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,8 +413,11 @@ impl PortKey {
     fn retrieve_port_io(&self, mod_def_core: &ModDefCore) -> IO {
         match self {
             PortKey::ModDefPort { port_name, .. } => mod_def_core.ports[port_name].clone(),
-            PortKey::ModInstPort { inst_name, port_name, .. } => 
-                mod_def_core.instances[inst_name].borrow().ports[port_name].clone(),
+            PortKey::ModInstPort {
+                inst_name,
+                port_name,
+                ..
+            } => mod_def_core.instances[inst_name].borrow().ports[port_name].clone(),
         }
     }
 }
@@ -788,7 +791,8 @@ impl ModDef {
         self.core.borrow().ports.contains_key(name.as_ref())
     }
 
-    /// Returns `true` if this module definition has an interface with the given name.
+    /// Returns `true` if this module definition has an interface with the given
+    /// name.
     pub fn has_interface(&self, name: impl AsRef<str>) -> bool {
         self.core.borrow().interfaces.contains_key(name.as_ref())
     }
@@ -1451,7 +1455,10 @@ since the width of that port is {}. Check the slice indices for this instance po
                         clk: &ports
                             .get(&pipeline.clk)
                             .unwrap_or_else(|| {
-                                panic!("Pipeline clock {} is not defined as a port of module {}.", pipeline.clk, core.name)
+                                panic!(
+                                    "Pipeline clock {} is not defined as a port of module {}.",
+                                    pipeline.clk, core.name
+                                )
                             })
                             .to_expr(),
                         width: lhs.width(),
@@ -1597,7 +1604,12 @@ since the width of that port is {}. Check the slice indices for this instance po
             }
         }
 
-        assert!(!mapping.is_empty(), "Empty interface definition for {}.{}", self.get_name(), name.as_ref());
+        assert!(
+            !mapping.is_empty(),
+            "Empty interface definition for {}.{}",
+            self.get_name(),
+            name.as_ref()
+        );
 
         self.def_intf(name, mapping)
     }
@@ -1636,7 +1648,12 @@ since the width of that port is {}. Check the slice indices for this instance po
             }
         }
 
-        assert!(!mapping.is_empty(), "Empty interface definition for {}.{}", self.get_name(), name.as_ref());
+        assert!(
+            !mapping.is_empty(),
+            "Empty interface definition for {}.{}",
+            self.get_name(),
+            name.as_ref()
+        );
 
         self.def_intf(name, mapping)
     }
@@ -2403,7 +2420,8 @@ impl Port {
         self.to_port_slice().feedthrough(moddef, flipped, original)
     }
 
-    /// Punches a feedthrough in the provided module definition for this port, with a pipeline.
+    /// Punches a feedthrough in the provided module definition for this port,
+    /// with a pipeline.
     pub fn feedthrough_pipeline(
         &self,
         moddef: &ModDef,
@@ -2411,30 +2429,32 @@ impl Port {
         original: impl AsRef<str>,
         pipeline: PipelineConfig,
     ) -> (Port, Port) {
-        self.to_port_slice().feedthrough_pipeline(moddef, flipped, original, pipeline)
+        self.to_port_slice()
+            .feedthrough_pipeline(moddef, flipped, original, pipeline)
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this port to another port or port slice.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this port to another port or port slice.
     pub fn connect_through<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         through: &[&ModInst],
-        prefix: impl AsRef<str>
+        prefix: impl AsRef<str>,
     ) {
         self.to_port_slice().connect_through(other, through, prefix);
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this port to another port or port slice, with optional pipelining for
-    /// each connection.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this port to another port or port slice, with
+    /// optional pipelining for each connection.
     pub fn connect_through_generic<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         through: &[(&ModInst, Option<PipelineConfig>)],
-        prefix: impl AsRef<str>
+        prefix: impl AsRef<str>,
     ) {
-        self.to_port_slice().connect_through_generic(other, through, prefix);
+        self.to_port_slice()
+            .connect_through_generic(other, through, prefix);
     }
 
     /// Ties off this port to the given constant value, specified as a `BigInt`
@@ -2535,7 +2555,8 @@ impl PortSlice {
             inst_name,
             port_name,
             mod_def_core,
-        } = &self.port {
+        } = &self.port
+        {
             let wire = Wire {
                 name: net.to_string(),
                 width: self.width(),
@@ -2549,13 +2570,17 @@ impl PortSlice {
                 core_borrowed
                     .reserved_net_definitions
                     .entry(net.to_string())
-                    .or_insert(wire.clone()).clone()
+                    .or_insert(wire.clone())
+                    .clone()
             };
 
             if existing_wire.width != self.width() {
                 panic!(
                     "Net width mismatch for {}.{}: existing width {}, new width {}",
-                    mod_def_core_unwrapped.borrow().name, net, existing_wire.width, self.width()
+                    mod_def_core_unwrapped.borrow().name,
+                    net,
+                    existing_wire.width,
+                    self.width()
                 );
             }
 
@@ -2760,7 +2785,8 @@ impl PortSlice {
         }
     }
 
-    /// Punches a feedthrough in the provided module definition for this port slice.
+    /// Punches a feedthrough in the provided module definition for this port
+    /// slice.
     pub fn feedthrough(
         &self,
         moddef: &ModDef,
@@ -2770,7 +2796,8 @@ impl PortSlice {
         self.feedthrough_generic(moddef, flipped, original, None)
     }
 
-    /// Punches a feedthrough in the provided module definition for this port slice, with a pipeline.
+    /// Punches a feedthrough in the provided module definition for this port
+    /// slice, with a pipeline.
     pub fn feedthrough_pipeline(
         &self,
         moddef: &ModDef,
@@ -2794,13 +2821,13 @@ impl PortSlice {
         (flipped_port, original_port)
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this port slice to another port or port slice.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this port slice to another port or port slice.
     pub fn connect_through<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         through: &[&ModInst],
-        prefix: impl AsRef<str>
+        prefix: impl AsRef<str>,
     ) {
         let mut through_generic = Vec::new();
         for inst in through {
@@ -2809,14 +2836,14 @@ impl PortSlice {
         self.connect_through_generic(other, &through_generic, prefix);
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this port slice to another port or port slice, with optional pipelining
-    /// for each connection.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this port slice to another port or port slice,
+    /// with optional pipelining for each connection.
     pub fn connect_through_generic<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         through: &[(&ModInst, Option<PipelineConfig>)],
-        prefix: impl AsRef<str>
+        prefix: impl AsRef<str>,
     ) {
         if through.is_empty() {
             self.connect(other);
@@ -2842,10 +2869,7 @@ impl PortSlice {
             if i == 0 {
                 self.connect(&flipped_port);
             } else {
-                through[i - 1]
-                    .0
-                    .get_port(&original)
-                    .connect(&flipped_port);
+                through[i - 1].0.get_port(&original).connect(&flipped_port);
             }
 
             if i == through.len() - 1 {
@@ -2909,7 +2933,8 @@ impl PortSlice {
 }
 
 impl ModInst {
-    /// Returns `true` if this module instance has an interface with the given name.
+    /// Returns `true` if this module instance has an interface with the given
+    /// name.
     pub fn has_interface(&self, name: impl AsRef<str>) -> bool {
         ModDef {
             core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
@@ -3233,8 +3258,10 @@ impl Intf {
         let x_port_slices = self.get_port_slices();
         let y_port_slices = other.get_port_slices();
 
-        for (x_func_name, y_func_name) in find_crossover_matches(self, other, pattern_a, pattern_b) {
-            x_port_slices[&x_func_name].connect_generic(&y_port_slices[&y_func_name], pipeline.clone());
+        for (x_func_name, y_func_name) in find_crossover_matches(self, other, pattern_a, pattern_b)
+        {
+            x_port_slices[&x_func_name]
+                .connect_generic(&y_port_slices[&y_func_name], pipeline.clone());
         }
     }
 
@@ -3372,7 +3399,12 @@ impl Intf {
         mod_def.def_intf(self.get_intf_name(), mapping)
     }
 
-    pub fn copy_to_with_prefix(&self, mod_def: &ModDef, name: impl AsRef<str>, prefix: impl AsRef<str>) -> Intf {
+    pub fn copy_to_with_prefix(
+        &self,
+        mod_def: &ModDef,
+        name: impl AsRef<str>,
+        prefix: impl AsRef<str>,
+    ) -> Intf {
         let mut mapping = IndexMap::new();
         for (func_name, port_slice) in self.get_port_slices() {
             let port_name = format!("{}{}", prefix.as_ref(), func_name);
@@ -3420,7 +3452,12 @@ impl Intf {
             let flipped_func = format!("{}_{}", flipped.as_ref(), func_name);
             let original_func = format!("{}_{}", original.as_ref(), func_name);
 
-            let (flipped_port, original_port) = port_slice.feedthrough_generic(moddef, flipped_func, original_func, pipeline.clone());
+            let (flipped_port, original_port) = port_slice.feedthrough_generic(
+                moddef,
+                flipped_func,
+                original_func,
+                pipeline.clone(),
+            );
 
             flipped_mapping.insert(
                 func_name.clone(),
@@ -3438,8 +3475,8 @@ impl Intf {
         (flipped_intf, original_intf)
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this interface to another interface.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this interface to another interface.
     pub fn connect_through(
         &self,
         other: &Intf,
@@ -3454,9 +3491,9 @@ impl Intf {
         self.connect_through_generic(other, &through_generic, prefix, allow_mismatch);
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this interface to another interface, with optional pipelining for
-    /// each connection.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this interface to another interface, with
+    /// optional pipelining for each connection.
     pub fn connect_through_generic(
         &self,
         other: &Intf,
@@ -3494,32 +3531,40 @@ impl Intf {
         }
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this interface to another interface, using a crossover pattern. For
-    /// example, one could have "^(.*)_tx$" and "^(.*)_rx$" as the patterns, and
-    /// this would connect the "tx" signals on this interface to the "rx" signals on
-    /// the other interface.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this interface to another interface, using a
+    /// crossover pattern. For example, one could have "^(.*)_tx$" and
+    /// "^(.*)_rx$" as the patterns, and this would connect the "tx" signals
+    /// on this interface to the "rx" signals on the other interface.
     pub fn crossover_through(
         &self,
         other: &Intf,
         through: &[&ModInst],
         pattern_a: impl AsRef<str>,
         pattern_b: impl AsRef<str>,
-        flipped_prefix: impl AsRef<str>,    
+        flipped_prefix: impl AsRef<str>,
         original_prefix: impl AsRef<str>,
     ) {
         let mut through_generic = Vec::new();
         for inst in through {
             through_generic.push((*inst, None));
         }
-        self.crossover_through_generic(other, &through_generic, pattern_a, pattern_b, flipped_prefix, original_prefix);
+        self.crossover_through_generic(
+            other,
+            &through_generic,
+            pattern_a,
+            pattern_b,
+            flipped_prefix,
+            original_prefix,
+        );
     }
 
-    /// Punches a sequence of feedthroughs through the specified module instances to
-    /// connect this interface to another interface, using a crossover pattern. For
-    /// example, one could have "^(.*)_tx$" and "^(.*)_rx$" as the patterns, and
-    /// this would connect the "tx" signals on this interface to the "rx" signals on
-    /// the other interface. Optional pipelining is used for each connection.
+    /// Punches a sequence of feedthroughs through the specified module
+    /// instances to connect this interface to another interface, using a
+    /// crossover pattern. For example, one could have "^(.*)_tx$" and
+    /// "^(.*)_rx$" as the patterns, and this would connect the "tx" signals
+    /// on this interface to the "rx" signals on the other interface.
+    /// Optional pipelining is used for each connection.
     pub fn crossover_through_generic(
         &self,
         other: &Intf,
@@ -3545,8 +3590,8 @@ impl Intf {
                 x_intf_port_slices[&x_func_name].feedthrough_generic(
                     &inst.get_mod_def(),
                     &flipped_name,
-                    &original_name, 
-                    pipeline.as_ref().cloned()
+                    &original_name,
+                    pipeline.as_ref().cloned(),
                 );
 
                 if i == 0 {
@@ -3557,7 +3602,7 @@ impl Intf {
                         .get_port(&original_name)
                         .connect(&inst.get_port(&flipped_name));
                 }
-    
+
                 if i == through.len() - 1 {
                     y_intf_port_slices[&y_func_name].connect(&inst.get_port(&original_name));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,7 +793,7 @@ impl ModDef {
 
     /// Returns `true` if this module definition has an interface with the given
     /// name.
-    pub fn has_interface(&self, name: impl AsRef<str>) -> bool {
+    pub fn has_intf(&self, name: impl AsRef<str>) -> bool {
         self.core.borrow().interfaces.contains_key(name.as_ref())
     }
 
@@ -2935,11 +2935,11 @@ impl PortSlice {
 impl ModInst {
     /// Returns `true` if this module instance has an interface with the given
     /// name.
-    pub fn has_interface(&self, name: impl AsRef<str>) -> bool {
+    pub fn has_intf(&self, name: impl AsRef<str>) -> bool {
         ModDef {
             core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
         }
-        .has_interface(name)
+        .has_intf(name)
     }
 
     /// Returns `true` if this module instance has a port with the given name.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,6 +788,11 @@ impl ModDef {
         self.core.borrow().ports.contains_key(name.as_ref())
     }
 
+    /// Returns `true` if this module definition has an interface with the given name.
+    pub fn has_interface(&self, name: impl AsRef<str>) -> bool {
+        self.core.borrow().interfaces.contains_key(name.as_ref())
+    }
+
     /// Returns the port on this module definition with the given name; panics
     /// if a port with that name does not exist.
     pub fn get_port(&self, name: impl AsRef<str>) -> Port {
@@ -1176,9 +1181,11 @@ impl ModDef {
                 }
                 let net_name = format!("{}_{}", inst_name, port_name);
                 if ports.contains_key(&net_name) {
-                    panic!(
-                        "{} is already declared as a port of the module containing this instance.",
-                        net_name
+                    panic!("Generated net name for instance port {}.{} collides with a port name on module definition {}: \
+both are called {}. Altering the instance name will likely fix this problem. connect_to_net() could also be used to \
+specify an alternate net name for this instance port, although that may be more labor-intensive since all connectivity \
+on that net will need to be updated.", 
+                        inst_name, port_name, core.name, net_name
                     );
                 }
                 let data_type = file.make_bit_vector_type(io.width() as i64, false);
@@ -1186,10 +1193,11 @@ impl ModDef {
                     .insert(net_name.clone(), module.add_wire(&net_name, &data_type))
                     .is_some()
                 {
-                    panic!(
-                        "Wire name {} is already declared in module {}",
-                        net_name, core.name
-                    );
+                    panic!("Generated net name for instance port {}.{} collides with another generated net name within \
+module definition {}: both are called {}. Altering the instance name will likely fix this problem. connect_to_net() could \
+also be used to specify an alternate net name for this instance port, although that may be more labor-intensive since all \
+connectivity on that net will need to be updated.",
+                        inst_name, port_name, core.name, net_name);
                 }
 
                 if inst.borrow().enum_ports.contains_key(port_name) {
@@ -1218,8 +1226,10 @@ impl ModDef {
                 )
                 .is_some()
             {
-                panic!(
-                    "Wire name {} is already declared in module {}",
+                panic!("connect_to_net()-specified net name {} already exists in module definition {}. \
+This is likely due to a collision with a generated net name, which has the form {{instance name}}_{{port name}}. \
+Two possible solutions: 1) change the instance name corresponding to the generated net name, or 2) provide an \
+alternate net name to connect_to_net().",
                     wire.name, core.name
                 );
             }
@@ -1260,8 +1270,9 @@ impl ModDef {
                         // create a filler if needed
                         if port_slice.inst_port_slice.msb as i64 > msb_expected {
                             panic!(
-                                "Instance connection index out of bounds for {}.{}",
-                                inst_name, port_name
+                                "Instance port slice index {} is out of bounds for instance port {}.{} in module {}, \
+since the width of that port is {}. Check the slice indices for this instance port.", 
+                                port_slice.inst_port_slice.msb, inst_name, port_name, core.name, io.width()
                             );
                         }
 
@@ -1277,7 +1288,8 @@ impl ModDef {
                             let wire = module.add_wire(&net_name, &data_type);
                             concat_entries.push(wire.to_expr());
                             if nets.insert(net_name.clone(), wire).is_some() {
-                                panic!("Wire name {} is already declared in this module", net_name);
+                                panic!("Generated net name {} for instance port {}.{} already exists in module definition \
+{}. If possible, changing the instance name will likely resolve this issue.", net_name, inst_name, port_name, core.name);
                             }
                         }
 
@@ -1313,7 +1325,8 @@ impl ModDef {
                         let wire = module.add_wire(&net_name, &data_type);
                         concat_entries.push(wire.to_expr());
                         if nets.insert(net_name.clone(), wire).is_some() {
-                            panic!("Wire name {} is already declared in this module", net_name);
+                            panic!("Generated net name {} for instance port {}.{} already exists in module definition \
+{}. If possible, changing the instance name will likely resolve this issue.", net_name, inst_name, port_name, core.name);
                         }
                     }
 
@@ -1438,7 +1451,7 @@ impl ModDef {
                         clk: &ports
                             .get(&pipeline.clk)
                             .unwrap_or_else(|| {
-                                panic!("Pipeline clock {}.{} not found.", core.name, pipeline.clk)
+                                panic!("Pipeline clock {} is not defined as a port of module {}.", pipeline.clk, core.name)
                             })
                             .to_expr(),
                         width: lhs.width(),
@@ -2896,6 +2909,14 @@ impl PortSlice {
 }
 
 impl ModInst {
+    /// Returns `true` if this module instance has an interface with the given name.
+    pub fn has_interface(&self, name: impl AsRef<str>) -> bool {
+        ModDef {
+            core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
+        }
+        .has_interface(name)
+    }
+
     /// Returns `true` if this module instance has a port with the given name.
     pub fn has_port(&self, name: impl AsRef<str>) -> bool {
         ModDef {
@@ -3209,42 +3230,11 @@ impl Intf {
         pattern_b: impl AsRef<str>,
         pipeline: Option<PipelineConfig>,
     ) {
-        let pattern_a_regex = Regex::new(pattern_a.as_ref()).unwrap();
-        let pattern_b_regex = Regex::new(pattern_b.as_ref()).unwrap();
+        let x_port_slices = self.get_port_slices();
+        let y_port_slices = other.get_port_slices();
 
-        let mut self_a_matches: IndexMap<String, PortSlice> = IndexMap::new();
-        let mut self_b_matches: IndexMap<String, PortSlice> = IndexMap::new();
-        let mut other_a_matches: IndexMap<String, PortSlice> = IndexMap::new();
-        let mut other_b_matches: IndexMap<String, PortSlice> = IndexMap::new();
-
-        const CONCAT_SEP: &str = "_";
-
-        for (func_name, port_slice) in self.get_port_slices() {
-            if let Some(captures) = pattern_a_regex.captures(&func_name) {
-                self_a_matches.insert(concat_captures(&captures, CONCAT_SEP), port_slice);
-            } else if let Some(captures) = pattern_b_regex.captures(&func_name) {
-                self_b_matches.insert(concat_captures(&captures, CONCAT_SEP), port_slice);
-            }
-        }
-
-        for (func_name, port_slice) in other.get_port_slices() {
-            if let Some(captures) = pattern_a_regex.captures(&func_name) {
-                other_a_matches.insert(concat_captures(&captures, CONCAT_SEP), port_slice);
-            } else if let Some(captures) = pattern_b_regex.captures(&func_name) {
-                other_b_matches.insert(concat_captures(&captures, CONCAT_SEP), port_slice);
-            }
-        }
-
-        for (func_name, self_a_port) in self_a_matches {
-            if let Some(other_b_port) = other_b_matches.get(&func_name) {
-                self_a_port.connect_generic(other_b_port, pipeline.clone());
-            }
-        }
-
-        for (func_name, self_b_port) in self_b_matches {
-            if let Some(other_a_port) = other_a_matches.get(&func_name) {
-                self_b_port.connect_generic(other_a_port, pipeline.clone());
-            }
+        for (x_func_name, y_func_name) in find_crossover_matches(self, other, pattern_a, pattern_b) {
+            x_port_slices[&x_func_name].connect_generic(&y_port_slices[&y_func_name], pipeline.clone());
         }
     }
 
@@ -3382,6 +3372,21 @@ impl Intf {
         mod_def.def_intf(self.get_intf_name(), mapping)
     }
 
+    pub fn copy_to_with_prefix(&self, mod_def: &ModDef, name: impl AsRef<str>, prefix: impl AsRef<str>) -> Intf {
+        let mut mapping = IndexMap::new();
+        for (func_name, port_slice) in self.get_port_slices() {
+            let port_name = format!("{}{}", prefix.as_ref(), func_name);
+            mod_def.add_port(&port_name, port_slice.port.io());
+            mapping.insert(func_name, (port_name, port_slice.width() - 1, 0));
+        }
+        mod_def.def_intf(name, mapping)
+    }
+
+    pub fn copy_to_with_name_underscore(&self, mod_def: &ModDef, name: impl AsRef<str>) -> Intf {
+        let prefix = format!("{}_", name.as_ref());
+        self.copy_to_with_prefix(mod_def, name, prefix)
+    }
+
     pub fn feedthrough(
         &self,
         moddef: &ModDef,
@@ -3500,13 +3505,14 @@ impl Intf {
         through: &[&ModInst],
         pattern_a: impl AsRef<str>,
         pattern_b: impl AsRef<str>,
-        prefix: impl AsRef<str>,
+        flipped_prefix: impl AsRef<str>,    
+        original_prefix: impl AsRef<str>,
     ) {
         let mut through_generic = Vec::new();
         for inst in through {
             through_generic.push((*inst, None));
         }
-        self.crossover_through_generic(other, &through_generic, pattern_a, pattern_b, prefix);
+        self.crossover_through_generic(other, &through_generic, pattern_a, pattern_b, flipped_prefix, original_prefix);
     }
 
     /// Punches a sequence of feedthroughs through the specified module instances to
@@ -3520,34 +3526,41 @@ impl Intf {
         through: &[(&ModInst, Option<PipelineConfig>)],
         pattern_a: impl AsRef<str>,
         pattern_b: impl AsRef<str>,
-        prefix: impl AsRef<str>,
+        flipped_prefix: impl AsRef<str>,
+        original_prefix: impl AsRef<str>,
     ) {
         if through.is_empty() {
             self.crossover(other, pattern_a, pattern_b);
             return;
         }
 
-        let flipped = format!("{}_flipped_{}", prefix.as_ref(), self.get_intf_name());
-        let original = format!("{}_original_{}", prefix.as_ref(), other.get_intf_name());
+        let matches = find_crossover_matches(self, other, pattern_a, pattern_b);
+        let x_intf_port_slices = self.get_port_slices();
+        let y_intf_port_slices = other.get_port_slices();
 
-        for (i, (inst, pipeline)) in through.iter().enumerate() {
-            self.feedthrough_generic(
-                &inst.get_mod_def(),
-                &flipped,
-                &original,
-                pipeline.as_ref().cloned(),
-            );
-            if i == 0 {
-                self.connect(&inst.get_intf(&flipped), false);
-            } else {
-                through[i - 1]
-                    .0
-                    .get_intf(&original)
-                    .connect(&inst.get_intf(&flipped), false);
-            }
+        for (x_func_name, y_func_name) in matches {
+            let flipped_name = format!("{}_{}", flipped_prefix.as_ref(), y_func_name);
+            let original_name = format!("{}_{}", original_prefix.as_ref(), x_func_name);
+            for (i, (inst, pipeline)) in through.iter().enumerate() {
+                x_intf_port_slices[&x_func_name].feedthrough_generic(
+                    &inst.get_mod_def(),
+                    &flipped_name,
+                    &original_name, 
+                    pipeline.as_ref().cloned()
+                );
 
-            if i == through.len() - 1 {
-                other.crossover(&inst.get_intf(&original), &pattern_a, &pattern_b);
+                if i == 0 {
+                    x_intf_port_slices[&x_func_name].connect(&inst.get_port(&flipped_name));
+                } else {
+                    through[i - 1]
+                        .0
+                        .get_port(&original_name)
+                        .connect(&inst.get_port(&flipped_name));
+                }
+    
+                if i == through.len() - 1 {
+                    y_intf_port_slices[&y_func_name].connect(&inst.get_port(&original_name));
+                }
             }
         }
     }
@@ -3892,4 +3905,53 @@ fn example_problematic_bits(value: &BigUint, width: usize) -> Option<String> {
     } else {
         None
     }
+}
+
+fn find_crossover_matches(
+    x: &Intf,
+    y: &Intf,
+    pattern_a: impl AsRef<str>,
+    pattern_b: impl AsRef<str>,
+) -> Vec<(String, String)> {
+    let mut matches = Vec::new();
+
+    let pattern_a_regex = Regex::new(pattern_a.as_ref()).unwrap();
+    let pattern_b_regex = Regex::new(pattern_b.as_ref()).unwrap();
+
+    let mut x_a_matches = IndexMap::new();
+    let mut x_b_matches = IndexMap::new();
+    let mut y_a_matches = IndexMap::new();
+    let mut y_b_matches = IndexMap::new();
+
+    const CONCAT_SEP: &str = "_";
+
+    for (x_func_name, _) in x.get_port_slices() {
+        if let Some(captures) = pattern_a_regex.captures(&x_func_name) {
+            x_a_matches.insert(concat_captures(&captures, CONCAT_SEP), x_func_name);
+        } else if let Some(captures) = pattern_b_regex.captures(&x_func_name) {
+            x_b_matches.insert(concat_captures(&captures, CONCAT_SEP), x_func_name);
+        }
+    }
+
+    for (y_func_name, _) in y.get_port_slices() {
+        if let Some(captures) = pattern_a_regex.captures(&y_func_name) {
+            y_a_matches.insert(concat_captures(&captures, CONCAT_SEP), y_func_name);
+        } else if let Some(captures) = pattern_b_regex.captures(&y_func_name) {
+            y_b_matches.insert(concat_captures(&captures, CONCAT_SEP), y_func_name);
+        }
+    }
+
+    for (key, x_func_name) in x_a_matches {
+        if let Some(y_func_name) = y_b_matches.get(&key) {
+            matches.push((x_func_name, y_func_name.clone()));
+        }
+    }
+
+    for (key, x_func_name) in x_b_matches {
+        if let Some(y_func_name) = y_a_matches.get(&key) {
+            matches.push((x_func_name, y_func_name.clone()));
+        }
+    }
+
+    matches
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4432,7 +4432,7 @@ endmodule
     }
 
     #[test]
-    fn test_has_interface() {
+    fn test_has_intf() {
         let module_a_verilog = "
     module ModuleA (
         output [31:0] a_data,
@@ -4454,8 +4454,8 @@ endmodule
         let module_a = ModDef::from_verilog("ModuleA", module_a_verilog, true, false);
         module_a.def_intf_from_prefix("a_intf", "a_");
 
-        assert!(module_a.has_interface("a_intf"));
-        assert!(!module_a.has_interface("b_intf"));
+        assert!(module_a.has_intf("a_intf"));
+        assert!(!module_a.has_intf("b_intf"));
 
         let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, false);
         module_b.def_intf_from_prefix("b_intf", "b_");
@@ -4464,8 +4464,8 @@ endmodule
 
         let b_inst = top_module.instantiate(&module_b, Some("inst_b"), None);
 
-        assert!(b_inst.has_interface("b_intf"));
-        assert!(!b_inst.has_interface("a_intf"));
+        assert!(b_inst.has_intf("b_intf"));
+        assert!(!b_inst.has_intf("a_intf"));
     }
 
     #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3638,13 +3638,8 @@ endmodule";
         let a_inst = c_mod_def.instantiate(&a_mod_def, Some("inst_a"), None);
         let b_inst = c_mod_def.instantiate(&b_mod_def, Some("inst_b"), None);
 
-        b_inst
-            .get_port("a")
-            .bit(0)
-            .connect(&a_inst.get_port("a0"));
-        a_inst
-            .get_port("a1")
-            .connect(&b_inst.get_port("a").bit(1));
+        b_inst.get_port("a").bit(0).connect(&a_inst.get_port("a0"));
+        a_inst.get_port("a1").connect(&b_inst.get_port("a").bit(1));
         a_inst.get_port("b").connect(&b_inst.get_port("b"));
         b_inst.get_port("c").connect(&a_inst.get_port("c"));
         b_inst.get_port("d").connect(&a_inst.get_port("d"));
@@ -3804,7 +3799,7 @@ endmodule
         sorted_module_names.sort();
         assert_eq!(sorted_module_names, vec!["A", "B", "C"]);
     }
-  
+
     #[test]
     fn test_protected() {
         let module_a_verilog = "
@@ -3833,7 +3828,7 @@ endmodule
 "
         );
     }
-  
+
     #[test]
     fn test_connect_to_net() {
         let a_verilog = "\
@@ -3994,7 +3989,9 @@ endmodule";
     }
 
     #[test]
-    #[should_panic(expected = "Net width mismatch for TopModule.custom: existing width 4, new width 8")]
+    #[should_panic(
+        expected = "Net width mismatch for TopModule.custom: existing width 4, new width 8"
+    )]
     fn test_connect_to_net_width_mismatch() {
         let a_verilog = "\
 module A(
@@ -4131,7 +4128,7 @@ endmodule";
         a_inst.get_port("a").connect_through(
             &e_inst.get_port("e"),
             &[&b_inst, &c_inst, &d_inst],
-            "ft"
+            "ft",
         );
 
         assert_eq!(
@@ -4231,7 +4228,7 @@ endmodule
         a_inst.get_port("a").connect_through_generic(
             &e_inst.get_port("e"),
             &[(&b_inst, cfg(0xab)), (&c_inst, None), (&d_inst, cfg(0xef))],
-            "ft"
+            "ft",
         );
 
         b_inst.get_port("clk").tieoff(0);
@@ -4341,7 +4338,9 @@ endmodule
         a.add_port("a", IO::Input(8)).unused();
 
         let b = ModDef::new("B");
-        a.get_port("a").slice(7, 4).feedthrough(&b, "flipped", "original");
+        a.get_port("a")
+            .slice(7, 4)
+            .feedthrough(&b, "flipped", "original");
 
         assert_eq!(
             b.emit(true),
@@ -4362,10 +4361,15 @@ endmodule
         a.add_port("a", IO::Input(8)).unused();
 
         let b = ModDef::new("B");
-        a.get_port("a").feedthrough_pipeline(&b, "flipped", "original", PipelineConfig {
-            clk: "clk".to_string(),
-            depth: 1,
-        });
+        a.get_port("a").feedthrough_pipeline(
+            &b,
+            "flipped",
+            "original",
+            PipelineConfig {
+                clk: "clk".to_string(),
+                depth: 1,
+            },
+        );
 
         assert_eq!(
             b.emit(true),
@@ -4395,10 +4399,15 @@ endmodule
         a.add_port("a", IO::Input(8)).unused();
 
         let b = ModDef::new("B");
-        a.get_port("a").slice(7, 4).feedthrough_pipeline(&b, "flipped", "original", PipelineConfig {
-            clk: "clk".to_string(),
-            depth: 1,
-        });
+        a.get_port("a").slice(7, 4).feedthrough_pipeline(
+            &b,
+            "flipped",
+            "original",
+            PipelineConfig {
+                clk: "clk".to_string(),
+                depth: 1,
+            },
+        );
 
         assert_eq!(
             b.emit(true),
@@ -4474,7 +4483,9 @@ endmodule
         module_a.def_intf_from_prefix("a", "a_");
 
         let module_b = ModDef::new("ModuleB");
-        let b_intf = module_a.get_intf("a").copy_to_with_prefix(&module_b, "b", "");
+        let b_intf = module_a
+            .get_intf("a")
+            .copy_to_with_prefix(&module_b, "b", "");
         b_intf.unused_and_tieoff(0);
 
         assert_eq!(
@@ -4507,7 +4518,9 @@ endmodule
         module_a.def_intf_from_name_underscore("a");
 
         let module_b = ModDef::new("ModuleB");
-        let b_intf = module_a.get_intf("a").copy_to_with_name_underscore(&module_b, "b");
+        let b_intf = module_a
+            .get_intf("a")
+            .copy_to_with_name_underscore(&module_b, "b");
         b_intf.unused_and_tieoff(0);
 
         assert_eq!(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2061,7 +2061,7 @@ endmodule
       module ModuleA (
           output [7:0] a_data_out,
           output a_valid_out,
-          input a_ready_in
+          input a_ready_out
       );
       endmodule
       ";
@@ -2070,7 +2070,7 @@ endmodule
       module ModuleE (
           input [7:0] e_data_in,
           input e_valid_in,
-          output e_ready_out
+          output e_ready_in
       );
       endmodule
       ";
@@ -2097,119 +2097,120 @@ endmodule
             &[&b_inst, &c_inst, &d_inst],
             "(.*)_out",
             "(.*)_in",
-            "ft",
+            "ft_x",
+            "ft_y",
         );
 
         assert_eq!(
             top_module.emit(true),
             "\
 module ModuleB(
-  input wire [7:0] ft_flipped_a_data_out,
-  output wire [7:0] ft_original_e_data_out,
-  input wire ft_flipped_a_valid_out,
-  output wire ft_original_e_valid_out,
-  output wire ft_flipped_a_ready_in,
-  input wire ft_original_e_ready_in
+  input wire [7:0] ft_x_data_in,
+  output wire [7:0] ft_y_data_out,
+  input wire ft_x_valid_in,
+  output wire ft_y_valid_out,
+  output wire ft_x_ready_in,
+  input wire ft_y_ready_out
 );
-  assign ft_original_e_data_out[7:0] = ft_flipped_a_data_out[7:0];
-  assign ft_original_e_valid_out = ft_flipped_a_valid_out;
-  assign ft_flipped_a_ready_in = ft_original_e_ready_in;
+  assign ft_y_data_out[7:0] = ft_x_data_in[7:0];
+  assign ft_y_valid_out = ft_x_valid_in;
+  assign ft_x_ready_in = ft_y_ready_out;
 endmodule
 module ModuleC(
-  input wire [7:0] ft_flipped_a_data_out,
-  output wire [7:0] ft_original_e_data_out,
-  input wire ft_flipped_a_valid_out,
-  output wire ft_original_e_valid_out,
-  output wire ft_flipped_a_ready_in,
-  input wire ft_original_e_ready_in
+  input wire [7:0] ft_x_data_in,
+  output wire [7:0] ft_y_data_out,
+  input wire ft_x_valid_in,
+  output wire ft_y_valid_out,
+  output wire ft_x_ready_in,
+  input wire ft_y_ready_out
 );
-  assign ft_original_e_data_out[7:0] = ft_flipped_a_data_out[7:0];
-  assign ft_original_e_valid_out = ft_flipped_a_valid_out;
-  assign ft_flipped_a_ready_in = ft_original_e_ready_in;
+  assign ft_y_data_out[7:0] = ft_x_data_in[7:0];
+  assign ft_y_valid_out = ft_x_valid_in;
+  assign ft_x_ready_in = ft_y_ready_out;
 endmodule
 module ModuleD(
-  input wire [7:0] ft_flipped_a_data_out,
-  output wire [7:0] ft_original_e_data_out,
-  input wire ft_flipped_a_valid_out,
-  output wire ft_original_e_valid_out,
-  output wire ft_flipped_a_ready_in,
-  input wire ft_original_e_ready_in
+  input wire [7:0] ft_x_data_in,
+  output wire [7:0] ft_y_data_out,
+  input wire ft_x_valid_in,
+  output wire ft_y_valid_out,
+  output wire ft_x_ready_in,
+  input wire ft_y_ready_out
 );
-  assign ft_original_e_data_out[7:0] = ft_flipped_a_data_out[7:0];
-  assign ft_original_e_valid_out = ft_flipped_a_valid_out;
-  assign ft_flipped_a_ready_in = ft_original_e_ready_in;
+  assign ft_y_data_out[7:0] = ft_x_data_in[7:0];
+  assign ft_y_valid_out = ft_x_valid_in;
+  assign ft_x_ready_in = ft_y_ready_out;
 endmodule
 module TopModule;
   wire [7:0] ModuleA_i_a_data_out;
   wire ModuleA_i_a_valid_out;
-  wire ModuleA_i_a_ready_in;
-  wire [7:0] ModuleB_i_ft_flipped_a_data_out;
-  wire [7:0] ModuleB_i_ft_original_e_data_out;
-  wire ModuleB_i_ft_flipped_a_valid_out;
-  wire ModuleB_i_ft_original_e_valid_out;
-  wire ModuleB_i_ft_flipped_a_ready_in;
-  wire ModuleB_i_ft_original_e_ready_in;
-  wire [7:0] ModuleC_i_ft_flipped_a_data_out;
-  wire [7:0] ModuleC_i_ft_original_e_data_out;
-  wire ModuleC_i_ft_flipped_a_valid_out;
-  wire ModuleC_i_ft_original_e_valid_out;
-  wire ModuleC_i_ft_flipped_a_ready_in;
-  wire ModuleC_i_ft_original_e_ready_in;
-  wire [7:0] ModuleD_i_ft_flipped_a_data_out;
-  wire [7:0] ModuleD_i_ft_original_e_data_out;
-  wire ModuleD_i_ft_flipped_a_valid_out;
-  wire ModuleD_i_ft_original_e_valid_out;
-  wire ModuleD_i_ft_flipped_a_ready_in;
-  wire ModuleD_i_ft_original_e_ready_in;
+  wire ModuleA_i_a_ready_out;
+  wire [7:0] ModuleB_i_ft_x_data_in;
+  wire [7:0] ModuleB_i_ft_y_data_out;
+  wire ModuleB_i_ft_x_valid_in;
+  wire ModuleB_i_ft_y_valid_out;
+  wire ModuleB_i_ft_x_ready_in;
+  wire ModuleB_i_ft_y_ready_out;
+  wire [7:0] ModuleC_i_ft_x_data_in;
+  wire [7:0] ModuleC_i_ft_y_data_out;
+  wire ModuleC_i_ft_x_valid_in;
+  wire ModuleC_i_ft_y_valid_out;
+  wire ModuleC_i_ft_x_ready_in;
+  wire ModuleC_i_ft_y_ready_out;
+  wire [7:0] ModuleD_i_ft_x_data_in;
+  wire [7:0] ModuleD_i_ft_y_data_out;
+  wire ModuleD_i_ft_x_valid_in;
+  wire ModuleD_i_ft_y_valid_out;
+  wire ModuleD_i_ft_x_ready_in;
+  wire ModuleD_i_ft_y_ready_out;
   wire [7:0] ModuleE_i_e_data_in;
   wire ModuleE_i_e_valid_in;
-  wire ModuleE_i_e_ready_out;
+  wire ModuleE_i_e_ready_in;
   ModuleA ModuleA_i (
     .a_data_out(ModuleA_i_a_data_out),
     .a_valid_out(ModuleA_i_a_valid_out),
-    .a_ready_in(ModuleA_i_a_ready_in)
+    .a_ready_out(ModuleA_i_a_ready_out)
   );
   ModuleB ModuleB_i (
-    .ft_flipped_a_data_out(ModuleB_i_ft_flipped_a_data_out),
-    .ft_original_e_data_out(ModuleB_i_ft_original_e_data_out),
-    .ft_flipped_a_valid_out(ModuleB_i_ft_flipped_a_valid_out),
-    .ft_original_e_valid_out(ModuleB_i_ft_original_e_valid_out),
-    .ft_flipped_a_ready_in(ModuleB_i_ft_flipped_a_ready_in),
-    .ft_original_e_ready_in(ModuleB_i_ft_original_e_ready_in)
+    .ft_x_data_in(ModuleB_i_ft_x_data_in),
+    .ft_y_data_out(ModuleB_i_ft_y_data_out),
+    .ft_x_valid_in(ModuleB_i_ft_x_valid_in),
+    .ft_y_valid_out(ModuleB_i_ft_y_valid_out),
+    .ft_x_ready_in(ModuleB_i_ft_x_ready_in),
+    .ft_y_ready_out(ModuleB_i_ft_y_ready_out)
   );
   ModuleC ModuleC_i (
-    .ft_flipped_a_data_out(ModuleC_i_ft_flipped_a_data_out),
-    .ft_original_e_data_out(ModuleC_i_ft_original_e_data_out),
-    .ft_flipped_a_valid_out(ModuleC_i_ft_flipped_a_valid_out),
-    .ft_original_e_valid_out(ModuleC_i_ft_original_e_valid_out),
-    .ft_flipped_a_ready_in(ModuleC_i_ft_flipped_a_ready_in),
-    .ft_original_e_ready_in(ModuleC_i_ft_original_e_ready_in)
+    .ft_x_data_in(ModuleC_i_ft_x_data_in),
+    .ft_y_data_out(ModuleC_i_ft_y_data_out),
+    .ft_x_valid_in(ModuleC_i_ft_x_valid_in),
+    .ft_y_valid_out(ModuleC_i_ft_y_valid_out),
+    .ft_x_ready_in(ModuleC_i_ft_x_ready_in),
+    .ft_y_ready_out(ModuleC_i_ft_y_ready_out)
   );
   ModuleD ModuleD_i (
-    .ft_flipped_a_data_out(ModuleD_i_ft_flipped_a_data_out),
-    .ft_original_e_data_out(ModuleD_i_ft_original_e_data_out),
-    .ft_flipped_a_valid_out(ModuleD_i_ft_flipped_a_valid_out),
-    .ft_original_e_valid_out(ModuleD_i_ft_original_e_valid_out),
-    .ft_flipped_a_ready_in(ModuleD_i_ft_flipped_a_ready_in),
-    .ft_original_e_ready_in(ModuleD_i_ft_original_e_ready_in)
+    .ft_x_data_in(ModuleD_i_ft_x_data_in),
+    .ft_y_data_out(ModuleD_i_ft_y_data_out),
+    .ft_x_valid_in(ModuleD_i_ft_x_valid_in),
+    .ft_y_valid_out(ModuleD_i_ft_y_valid_out),
+    .ft_x_ready_in(ModuleD_i_ft_x_ready_in),
+    .ft_y_ready_out(ModuleD_i_ft_y_ready_out)
   );
   ModuleE ModuleE_i (
     .e_data_in(ModuleE_i_e_data_in),
     .e_valid_in(ModuleE_i_e_valid_in),
-    .e_ready_out(ModuleE_i_e_ready_out)
+    .e_ready_in(ModuleE_i_e_ready_in)
   );
-  assign ModuleB_i_ft_flipped_a_data_out[7:0] = ModuleA_i_a_data_out[7:0];
-  assign ModuleB_i_ft_flipped_a_valid_out = ModuleA_i_a_valid_out;
-  assign ModuleA_i_a_ready_in = ModuleB_i_ft_flipped_a_ready_in;
-  assign ModuleC_i_ft_flipped_a_data_out[7:0] = ModuleB_i_ft_original_e_data_out[7:0];
-  assign ModuleC_i_ft_flipped_a_valid_out = ModuleB_i_ft_original_e_valid_out;
-  assign ModuleB_i_ft_original_e_ready_in = ModuleC_i_ft_flipped_a_ready_in;
-  assign ModuleD_i_ft_flipped_a_data_out[7:0] = ModuleC_i_ft_original_e_data_out[7:0];
-  assign ModuleD_i_ft_flipped_a_valid_out = ModuleC_i_ft_original_e_valid_out;
-  assign ModuleC_i_ft_original_e_ready_in = ModuleD_i_ft_flipped_a_ready_in;
-  assign ModuleD_i_ft_original_e_ready_in = ModuleE_i_e_ready_out;
-  assign ModuleE_i_e_data_in[7:0] = ModuleD_i_ft_original_e_data_out[7:0];
-  assign ModuleE_i_e_valid_in = ModuleD_i_ft_original_e_valid_out;
+  assign ModuleB_i_ft_x_data_in[7:0] = ModuleA_i_a_data_out[7:0];
+  assign ModuleC_i_ft_x_data_in[7:0] = ModuleB_i_ft_y_data_out[7:0];
+  assign ModuleD_i_ft_x_data_in[7:0] = ModuleC_i_ft_y_data_out[7:0];
+  assign ModuleE_i_e_data_in[7:0] = ModuleD_i_ft_y_data_out[7:0];
+  assign ModuleB_i_ft_x_valid_in = ModuleA_i_a_valid_out;
+  assign ModuleC_i_ft_x_valid_in = ModuleB_i_ft_y_valid_out;
+  assign ModuleD_i_ft_x_valid_in = ModuleC_i_ft_y_valid_out;
+  assign ModuleE_i_e_valid_in = ModuleD_i_ft_y_valid_out;
+  assign ModuleA_i_a_ready_out = ModuleB_i_ft_x_ready_in;
+  assign ModuleB_i_ft_y_ready_out = ModuleC_i_ft_x_ready_in;
+  assign ModuleC_i_ft_y_ready_out = ModuleD_i_ft_x_ready_in;
+  assign ModuleD_i_ft_y_ready_out = ModuleE_i_e_ready_in;
 endmodule
 "
         );
@@ -3477,7 +3478,8 @@ endmodule
             &[(&b_inst, cfg(0xab)), (&c_inst, None), (&d_inst, cfg(0xef))],
             "tx",
             "rx",
-            "ft",
+            "ft_x",
+            "ft_y",
         );
 
         b_inst.get_port("clk").tieoff(0);
@@ -3487,19 +3489,19 @@ endmodule
             top_module.emit(true),
             "\
 module ModuleB(
-  input wire [7:0] ft_flipped_a_tx,
-  output wire [7:0] ft_original_e_tx,
+  input wire [7:0] ft_x_rx,
+  output wire [7:0] ft_y_tx,
   input wire clk,
-  output wire [7:0] ft_flipped_a_rx,
-  input wire [7:0] ft_original_e_rx
+  output wire [7:0] ft_x_tx,
+  input wire [7:0] ft_y_rx
 );
   br_delay_nr #(
     .Width(32'h0000_0008),
     .NumStages(32'h0000_00ab)
   ) pipeline_conn_0 (
     .clk(clk),
-    .in(ft_flipped_a_tx[7:0]),
-    .out(ft_original_e_tx[7:0]),
+    .in(ft_x_rx[7:0]),
+    .out(ft_y_tx[7:0]),
     .out_stages()
   );
   br_delay_nr #(
@@ -3507,34 +3509,34 @@ module ModuleB(
     .NumStages(32'h0000_00ab)
   ) pipeline_conn_1 (
     .clk(clk),
-    .in(ft_original_e_rx[7:0]),
-    .out(ft_flipped_a_rx[7:0]),
+    .in(ft_y_rx[7:0]),
+    .out(ft_x_tx[7:0]),
     .out_stages()
   );
 endmodule
 module ModuleC(
-  input wire [7:0] ft_flipped_a_tx,
-  output wire [7:0] ft_original_e_tx,
-  output wire [7:0] ft_flipped_a_rx,
-  input wire [7:0] ft_original_e_rx
+  input wire [7:0] ft_x_rx,
+  output wire [7:0] ft_y_tx,
+  output wire [7:0] ft_x_tx,
+  input wire [7:0] ft_y_rx
 );
-  assign ft_original_e_tx[7:0] = ft_flipped_a_tx[7:0];
-  assign ft_flipped_a_rx[7:0] = ft_original_e_rx[7:0];
+  assign ft_y_tx[7:0] = ft_x_rx[7:0];
+  assign ft_x_tx[7:0] = ft_y_rx[7:0];
 endmodule
 module ModuleD(
-  input wire [7:0] ft_flipped_a_tx,
-  output wire [7:0] ft_original_e_tx,
+  input wire [7:0] ft_x_rx,
+  output wire [7:0] ft_y_tx,
   input wire clk,
-  output wire [7:0] ft_flipped_a_rx,
-  input wire [7:0] ft_original_e_rx
+  output wire [7:0] ft_x_tx,
+  input wire [7:0] ft_y_rx
 );
   br_delay_nr #(
     .Width(32'h0000_0008),
     .NumStages(32'h0000_00ef)
   ) pipeline_conn_0 (
     .clk(clk),
-    .in(ft_flipped_a_tx[7:0]),
-    .out(ft_original_e_tx[7:0]),
+    .in(ft_x_rx[7:0]),
+    .out(ft_y_tx[7:0]),
     .out_stages()
   );
   br_delay_nr #(
@@ -3542,26 +3544,26 @@ module ModuleD(
     .NumStages(32'h0000_00ef)
   ) pipeline_conn_1 (
     .clk(clk),
-    .in(ft_original_e_rx[7:0]),
-    .out(ft_flipped_a_rx[7:0]),
+    .in(ft_y_rx[7:0]),
+    .out(ft_x_tx[7:0]),
     .out_stages()
   );
 endmodule
 module TopModule;
   wire [7:0] ModuleA_i_a_tx;
   wire [7:0] ModuleA_i_a_rx;
-  wire [7:0] ModuleB_i_ft_flipped_a_tx;
-  wire [7:0] ModuleB_i_ft_original_e_tx;
-  wire [7:0] ModuleB_i_ft_flipped_a_rx;
-  wire [7:0] ModuleB_i_ft_original_e_rx;
-  wire [7:0] ModuleC_i_ft_flipped_a_tx;
-  wire [7:0] ModuleC_i_ft_original_e_tx;
-  wire [7:0] ModuleC_i_ft_flipped_a_rx;
-  wire [7:0] ModuleC_i_ft_original_e_rx;
-  wire [7:0] ModuleD_i_ft_flipped_a_tx;
-  wire [7:0] ModuleD_i_ft_original_e_tx;
-  wire [7:0] ModuleD_i_ft_flipped_a_rx;
-  wire [7:0] ModuleD_i_ft_original_e_rx;
+  wire [7:0] ModuleB_i_ft_x_rx;
+  wire [7:0] ModuleB_i_ft_y_tx;
+  wire [7:0] ModuleB_i_ft_x_tx;
+  wire [7:0] ModuleB_i_ft_y_rx;
+  wire [7:0] ModuleC_i_ft_x_rx;
+  wire [7:0] ModuleC_i_ft_y_tx;
+  wire [7:0] ModuleC_i_ft_x_tx;
+  wire [7:0] ModuleC_i_ft_y_rx;
+  wire [7:0] ModuleD_i_ft_x_rx;
+  wire [7:0] ModuleD_i_ft_y_tx;
+  wire [7:0] ModuleD_i_ft_x_tx;
+  wire [7:0] ModuleD_i_ft_y_rx;
   wire [7:0] ModuleE_i_e_rx;
   wire [7:0] ModuleE_i_e_tx;
   ModuleA ModuleA_i (
@@ -3569,37 +3571,37 @@ module TopModule;
     .a_rx(ModuleA_i_a_rx)
   );
   ModuleB ModuleB_i (
-    .ft_flipped_a_tx(ModuleB_i_ft_flipped_a_tx),
-    .ft_original_e_tx(ModuleB_i_ft_original_e_tx),
+    .ft_x_rx(ModuleB_i_ft_x_rx),
+    .ft_y_tx(ModuleB_i_ft_y_tx),
     .clk(1'h0),
-    .ft_flipped_a_rx(ModuleB_i_ft_flipped_a_rx),
-    .ft_original_e_rx(ModuleB_i_ft_original_e_rx)
+    .ft_x_tx(ModuleB_i_ft_x_tx),
+    .ft_y_rx(ModuleB_i_ft_y_rx)
   );
   ModuleC ModuleC_i (
-    .ft_flipped_a_tx(ModuleC_i_ft_flipped_a_tx),
-    .ft_original_e_tx(ModuleC_i_ft_original_e_tx),
-    .ft_flipped_a_rx(ModuleC_i_ft_flipped_a_rx),
-    .ft_original_e_rx(ModuleC_i_ft_original_e_rx)
+    .ft_x_rx(ModuleC_i_ft_x_rx),
+    .ft_y_tx(ModuleC_i_ft_y_tx),
+    .ft_x_tx(ModuleC_i_ft_x_tx),
+    .ft_y_rx(ModuleC_i_ft_y_rx)
   );
   ModuleD ModuleD_i (
-    .ft_flipped_a_tx(ModuleD_i_ft_flipped_a_tx),
-    .ft_original_e_tx(ModuleD_i_ft_original_e_tx),
+    .ft_x_rx(ModuleD_i_ft_x_rx),
+    .ft_y_tx(ModuleD_i_ft_y_tx),
     .clk(1'h0),
-    .ft_flipped_a_rx(ModuleD_i_ft_flipped_a_rx),
-    .ft_original_e_rx(ModuleD_i_ft_original_e_rx)
+    .ft_x_tx(ModuleD_i_ft_x_tx),
+    .ft_y_rx(ModuleD_i_ft_y_rx)
   );
   ModuleE ModuleE_i (
     .e_rx(ModuleE_i_e_rx),
     .e_tx(ModuleE_i_e_tx)
   );
-  assign ModuleB_i_ft_flipped_a_tx[7:0] = ModuleA_i_a_tx[7:0];
-  assign ModuleA_i_a_rx[7:0] = ModuleB_i_ft_flipped_a_rx[7:0];
-  assign ModuleC_i_ft_flipped_a_tx[7:0] = ModuleB_i_ft_original_e_tx[7:0];
-  assign ModuleB_i_ft_original_e_rx[7:0] = ModuleC_i_ft_flipped_a_rx[7:0];
-  assign ModuleD_i_ft_flipped_a_tx[7:0] = ModuleC_i_ft_original_e_tx[7:0];
-  assign ModuleC_i_ft_original_e_rx[7:0] = ModuleD_i_ft_flipped_a_rx[7:0];
-  assign ModuleD_i_ft_original_e_rx[7:0] = ModuleE_i_e_tx[7:0];
-  assign ModuleE_i_e_rx[7:0] = ModuleD_i_ft_original_e_tx[7:0];
+  assign ModuleB_i_ft_x_rx[7:0] = ModuleA_i_a_tx[7:0];
+  assign ModuleC_i_ft_x_rx[7:0] = ModuleB_i_ft_y_tx[7:0];
+  assign ModuleD_i_ft_x_rx[7:0] = ModuleC_i_ft_y_tx[7:0];
+  assign ModuleE_i_e_rx[7:0] = ModuleD_i_ft_y_tx[7:0];
+  assign ModuleA_i_a_rx[7:0] = ModuleB_i_ft_x_tx[7:0];
+  assign ModuleB_i_ft_y_rx[7:0] = ModuleC_i_ft_x_tx[7:0];
+  assign ModuleC_i_ft_y_rx[7:0] = ModuleD_i_ft_x_tx[7:0];
+  assign ModuleD_i_ft_y_rx[7:0] = ModuleE_i_e_tx[7:0];
 endmodule
 "
         );
@@ -4415,6 +4417,109 @@ module B(
     .out(flipped[3:0]),
     .out_stages()
   );
+endmodule
+"
+        );
+    }
+
+    #[test]
+    fn test_has_interface() {
+        let module_a_verilog = "
+    module ModuleA (
+        output [31:0] a_data,
+        output a_valid,
+        input a_ready
+    );
+    endmodule
+    ";
+
+        let module_b_verilog = "
+    module ModuleB (
+        input [31:0] b_data,
+        input b_valid,
+        output b_ready
+    );
+    endmodule
+    ";
+
+        let module_a = ModDef::from_verilog("ModuleA", module_a_verilog, true, false);
+        module_a.def_intf_from_prefix("a_intf", "a_");
+
+        assert!(module_a.has_interface("a_intf"));
+        assert!(!module_a.has_interface("b_intf"));
+
+        let module_b = ModDef::from_verilog("ModuleB", module_b_verilog, true, false);
+        module_b.def_intf_from_prefix("b_intf", "b_");
+
+        let top_module = ModDef::new("TopModule");
+
+        let b_inst = top_module.instantiate(&module_b, Some("inst_b"), None);
+
+        assert!(b_inst.has_interface("b_intf"));
+        assert!(!b_inst.has_interface("a_intf"));
+    }
+
+    #[test]
+    fn test_intf_copy_to_with_prefix() {
+        let module_a_verilog = "
+    module ModuleA (
+        output [31:0] a_data,
+        output a_valid,
+        input a_ready
+    );
+    endmodule
+    ";
+
+        let module_a = ModDef::from_verilog("ModuleA", module_a_verilog, true, false);
+        module_a.def_intf_from_prefix("a", "a_");
+
+        let module_b = ModDef::new("ModuleB");
+        let b_intf = module_a.get_intf("a").copy_to_with_prefix(&module_b, "b", "");
+        b_intf.unused_and_tieoff(0);
+
+        assert_eq!(
+            module_b.emit(true),
+            "\
+module ModuleB(
+  output wire [31:0] data,
+  output wire valid,
+  input wire ready
+);
+  assign data[31:0] = 32'h0000_0000;
+  assign valid = 1'h0;
+endmodule
+"
+        );
+    }
+
+    #[test]
+    fn test_intf_copy_to_with_name_underscore() {
+        let module_a_verilog = "
+    module ModuleA (
+        output [31:0] a_data,
+        output a_valid,
+        input a_ready
+    );
+    endmodule
+    ";
+
+        let module_a = ModDef::from_verilog("ModuleA", module_a_verilog, true, false);
+        module_a.def_intf_from_name_underscore("a");
+
+        let module_b = ModDef::new("ModuleB");
+        let b_intf = module_a.get_intf("a").copy_to_with_name_underscore(&module_b, "b");
+        b_intf.unused_and_tieoff(0);
+
+        assert_eq!(
+            module_b.emit(true),
+            "\
+module ModuleB(
+  output wire [31:0] b_data,
+  output wire b_valid,
+  input wire b_ready
+);
+  assign b_data[31:0] = 32'h0000_0000;
+  assign b_valid = 1'h0;
 endmodule
 "
         );


### PR DESCRIPTION
* Update the behavior of `crossover_through` and its variants so that port names flip at every interface, as opposed to only at the endpoints of the crossover connection. This means that, for example, if we are crossing over `data_out` to `data_in` through multiple instances, the instances where feedthroughs are punched will have `data_in` and `data_out` ports with the expected directionality. While the logical connectivity is the same as before, the port naming is much easier to interpret (and arguably more correct).
* `copy_to_with_prefix()` and `copy_to_with_name_underscore()` methods for copying an interface to a module definition with more control over the naming.
* More descriptive error messages for generated net name collisions, including suggestions on how to fix the errors. Eventually, I would like to make net name generation smarter to avoid the possibility for collisions, but that will be a more involved change since various parts of the code rely of the current naming scheme.
* `has_intf` method for `ModDef` and `ModInst`