### PR TITLE
Fix issue with preprocessor define and `parameterize()` being used together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"


### PR DESCRIPTION
Preprocessor defines were being ignored when re-running the parser on the parameterized version of a module.

Also in this PR: a fix for a bug in `copy_to` methods relating to the treatment of port slices. 