### PR TITLE
Pass top-level module name explicitly to slang when reparameterizing module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1912,6 +1912,7 @@ since the width of that port is {}. Check the slice indices for this instance po
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect::<Vec<_>>(),
+            tops: &[&core.name],
             defines: defines.as_slice(),
             ignore_unknown_modules: core.verilog_import.as_ref().unwrap().ignore_unknown_modules,
             ..Default::default()


### PR DESCRIPTION
In some cases, slang cannot infer the top-level module without it being
explicitly provided. The `parameterize` function doesn't do this, which
causes issues when reparsing. Pass the module name explciitly in `tops`
to solve this.