### PR TITLE
Usability updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/funnel.rs
+++ b/src/funnel.rs
@@ -116,11 +116,12 @@ impl Funnel {
             } else {
                 assert!(
                     self.a_in_offset + a.width() <= self.a_in.width(),
-                    "Funnel error: out of capacity when trying to connect {} -> {} via {} -> {}",
+                    "Funnel error: out of capacity when trying to connect {} -> {} via {} -> {}. Would need {} extra bit(s).",
                     a.debug_string(),
                     b.debug_string(),
                     self.a_in.debug_string(),
-                    self.b_out.debug_string()
+                    self.b_out.debug_string(),
+                    self.a_in_offset + a.width() - self.a_in.width()
                 );
                 self.a_in
                     .slice_relative(self.a_in_offset, a.width())
@@ -133,11 +134,12 @@ impl Funnel {
         } else if b.port.is_driver() {
             assert!(
                 self.a_out_offset + a.width() <= self.a_out.width(),
-                "Funnel error: out of capacity when trying to connect {} -> {} via {} -> {}",
+                "Funnel error: out of capacity when trying to connect {} -> {} via {} -> {}. Would need {} extra bit(s).",
                 b.debug_string(),
                 a.debug_string(),
                 self.b_in.debug_string(),
-                self.a_out.debug_string()
+                self.a_out.debug_string(),
+                self.a_out_offset + a.width() - self.a_out.width()
             );
             self.a_out
                 .slice_relative(self.a_out_offset, a.width())

--- a/src/intf.rs
+++ b/src/intf.rs
@@ -16,6 +16,7 @@ mod export;
 mod feedthrough;
 mod subdivide;
 mod tieoff;
+mod width;
 
 /// Represents an interface on a module definition or module instance.
 /// Interfaces are used to connect modules together by function name.

--- a/src/intf/width.rs
+++ b/src/intf/width.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Intf;
+
+impl Intf {
+    pub fn width(&self) -> usize {
+        self.get_port_slices()
+            .values()
+            .map(|slice| slice.width())
+            .sum()
+    }
+}

--- a/src/mod_inst.rs
+++ b/src/mod_inst.rs
@@ -14,6 +14,11 @@ pub struct ModInst {
 }
 
 impl ModInst {
+    /// Returns the name of this module instance.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Returns `true` if this module instance has an interface with the given
     /// name.
     pub fn has_intf(&self, name: impl AsRef<str>) -> bool {

--- a/tests/interfaces/intf.rs
+++ b/tests/interfaces/intf.rs
@@ -36,6 +36,9 @@ fn test_interfaces() {
     let a_intf = a_inst.get_intf("a_intf");
     let b_intf = b_inst.get_intf("b_intf");
 
+    assert_eq!(a_intf.width(), 34);
+    assert_eq!(b_intf.width(), 34);
+
     a_intf.connect(&b_intf, false);
 
     assert_eq!(


### PR DESCRIPTION
* Add a `width()` method for interfaces.
* Add more debugging information to the funnel capacity error message.
* Add a `name()` method to retrieve the name of a `ModInst`