### PR TITLE
Add publish action + various checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# adapted from https://github.com/xlsynth/xlsynth-crate/blob/main/.github/workflows/ci.yml
+
 name: Rust CI
 
 on:
@@ -8,12 +12,42 @@ on:
       - main
 
 jobs:
-  test:
-
+  # -----------------------------------------------------------
+  # 1) Lint-check / pre-commit gate
+  # -----------------------------------------------------------
+  lint-check:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python + pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        env:
+          SKIP: no-commit-to-branch
+        run: |
+          pre-commit install
+          pre-commit run --all-files
+
+  # -----------------------------------------------------------
+  # 2) Build/test
+  # -----------------------------------------------------------
+  build-and-test:
+    needs: [lint-check]  # Ensure lint checks pass first
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]  # TODO: add more OSes in the future
+      fail-fast: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
 
       - name: Download Slang
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# adapted from https://github.com/xlsynth/xlsynth-crate/blob/main/.github/workflows/publish.yml
+
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - 'v*' # This will trigger the workflow on version tags like v1.0.0, v0.1.0, etc.
+
+jobs:
+  publish:
+    runs-on: macos-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Validate version matches
+      run: |
+        # GITHUB_REF will be something like "refs/tags/v0.0.57"
+        # We'll strip off the "refs/tags/" part, leaving "v0.0.57".
+        VERSION="${GITHUB_REF#refs/tags/}"
+
+        # Now invoke the Python script, passing the version.
+        python check_version_is.py "$VERSION"
+
+    - name: Download Slang
+      run: |
+        curl -L -o slang "https://github.com/xlsynth/slang-rs/releases/download/ci/slang"
+        chmod +x slang
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Cache Cargo registry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+
+    - name: Cache Cargo index
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-index-
+
+    - name: Build and test
+      run: |
+        export SLANG_PATH=`realpath slang`
+        cargo test
+
+    - name: Publish topstitch to crates.io
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      run: |
+        cargo publish --token $CARGO_REGISTRY_TOKEN

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# adapted from:
+# * https://github.com/xlsynth/xlsynth-crate/blob/main/.pre-commit-config.yaml
+# * https://github.com/xlsynth/bedrock-rtl/blob/main/.pre-commit-config.yaml
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: trailing-whitespace
+        exclude: "^(tests/feedthroughs/pipeline.rs)|(tests/modifications/stub.rs)$"
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-ast
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key
+      - id: debug-statements
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        description: Check if all files follow the rustfmt style
+        entry: cargo fmt --all -- --check --color always
+        language: system
+        pass_filenames: false
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17  # Use a version that supports Python 3.8
+    hooks:
+    - id: mdformat

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+wrap_comments = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +234,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.80+curl-8.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f7df2eac63200c3ab25bde3b2268ef2ee56af3d238e76d61f01c3c49bff734"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +300,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,12 +330,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -355,7 +464,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -443,6 +564,12 @@ name = "httparse"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -672,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -711,6 +844,18 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -760,7 +905,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -820,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
@@ -1055,7 +1200,7 @@ checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1069,15 +1214,15 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1376,12 +1521,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1466,14 +1612,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "topstitch"
-version = "0.51.0"
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "topstitch"
+version = "0.52.0"
+dependencies = [
+ "cargo_metadata",
+ "curl",
+ "env_logger",
  "indexmap",
  "itertools",
+ "log",
  "num-bigint",
  "regex",
+ "semver",
+ "serde_json",
  "slang-rs",
+ "tempfile",
+ "toml",
  "xlsynth",
 ]
 
@@ -1577,6 +1740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1771,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1813,6 +1991,15 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -15,3 +15,13 @@ xlsynth = "0.0.73"
 slang-rs = "0.15.0"
 itertools = "0.10"
 regex = "1.11.0"
+
+[dev-dependencies]
+cargo_metadata = "0.18"
+tempfile = "3"
+curl = "0.4"
+serde_json = "1.0"
+log = "0.4"
+toml = "0.5"
+semver = "1.0"
+env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # topstitch
+
 Stitch together Verilog modules with Rust.
 
 Note: the API is currently under development and is subject to frequent changes.
@@ -36,6 +37,7 @@ If you want to simulate the Verilog code that is produced, first install Icarus 
 ```
 
 This will produce the following output:
+
 ```shell
  597
 demo.sv:16: $finish called at 0 (1s)
@@ -61,4 +63,26 @@ not to the directory path; e.g.
 
 ```
 $ export SLANG_PATH=$HOME/src/slang/build/bin/slang
+```
+
+## Development
+
+We use [pre-commit](https://pre-commit.com/) as part of our CI pipeline.
+
+If you haven't already installed `pre-commit`, you can do so with:
+
+```shell
+pip install pre-commit
+```
+
+Then install the pre-commit hooks for this repository with:
+
+```shell
+pre-commit install
+```
+
+The pre-commit hooks will run automatically when you attempt to commit code. You can also run pre-commit checks on-demand with:
+
+```shell
+pre-commit run
 ```

--- a/check_version_is.py
+++ b/check_version_is.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+# from https://github.com/xlsynth/xlsynth-crate/blob/main/check_version_is.py
+
+import sys
+import re
+import os
+
+if len(sys.argv) < 2:
+    print("Usage: check_version_is.py <version>")
+    sys.exit(1)
+
+# The argument might be e.g. "v0.0.57" or "0.0.57"
+arg_version = sys.argv[1]
+print(f"Argument version: {arg_version!r}")
+
+# If you expect the script to always receive e.g. "v0.0.57",
+# you can strip the leading 'v' here:
+tag_version = arg_version.lstrip('v')
+print(f"Tag version:       {tag_version!r}")
+
+# Read the version from xlsynth-sys/Cargo.toml
+toml_path = os.path.join("xlsynth-sys", "Cargo.toml")
+with open(toml_path, "r", encoding="utf-8") as f:
+    cargo_toml = f.read()
+
+print(f"Cargo.toml: {cargo_toml!r}")
+
+# Use a regex to extract the version from a line like: version = "0.0.57"
+match = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE)
+if not match:
+    print("Error: Could not find a valid `version = \"...\"` line in xlsynth-sys/Cargo.toml.")
+    sys.exit(1)
+
+cargo_version = match.group(1)
+
+print(f"Tag version:       {tag_version!r}")
+print(f"Cargo.toml version: {cargo_version!r}")
+
+# Compare the extracted version with the tag version
+if cargo_version != tag_version:
+    print(
+        f"Error: version mismatch. "
+        f"Tag is {tag_version!r}, but xlsynth-sys/Cargo.toml is {cargo_version!r}."
+    )
+    sys.exit(1)
+
+print("Success: Tag version matches Cargo.toml version.")

--- a/examples/tb/demo.sh
+++ b/examples/tb/demo.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/src/mod_def/emit.rs
+++ b/src/mod_def/emit.rs
@@ -160,7 +160,7 @@ impl ModDef {
                     panic!("Generated net name for instance port {}.{} collides with a port name on module definition {}: \
 both are called {}. Altering the instance name will likely fix this problem. connect_to_net() could also be used to \
 specify an alternate net name for this instance port, although that may be more labor-intensive since all connectivity \
-on that net will need to be updated.", 
+on that net will need to be updated.",
                         inst_name, port_name, core.name, net_name
                     );
                 }
@@ -247,7 +247,7 @@ alternate net name to connect_to_net().",
                         if port_slice.inst_port_slice.msb as i64 > msb_expected {
                             panic!(
                                 "Instance port slice index {} is out of bounds for instance port {}.{} in module {}, \
-since the width of that port is {}. Check the slice indices for this instance port.", 
+since the width of that port is {}. Check the slice indices for this instance port.",
                                 port_slice.inst_port_slice.msb, inst_name, port_name, core.name, io.width()
                             );
                         }

--- a/tests/spdx_test.rs
+++ b/tests/spdx_test.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// adapted from https://github.com/xlsynth/xlsynth-crate/blob/main/test-helpers/tests/spdx_test.rs
+
+use cargo_metadata::MetadataCommand;
+use std::fs;
+use std::io::{self, BufRead};
+use std::path::{Path, PathBuf};
+
+fn check_spdx_identifier(file_path: &Path) -> bool {
+    let filename = file_path.file_name().unwrap().to_str().unwrap();
+    let comment_prefix = if filename.ends_with(".yml")
+        || filename.ends_with(".yaml")
+        || filename.ends_with(".py")
+        || filename.ends_with(".sh")
+    {
+        "#"
+    } else {
+        "//"
+    };
+    let expect_shebang = filename.ends_with(".py") || filename.ends_with(".sh");
+    let expected_spdx_identifier = format!("{comment_prefix} SPDX-License-Identifier: Apache-2.0");
+
+    let file = fs::File::open(file_path).unwrap();
+    let reader = io::BufReader::new(file);
+    let mut lines = reader.lines();
+    let ok = if expect_shebang {
+        let first_line = lines.next().unwrap().unwrap();
+        if first_line.starts_with("#!") {
+            lines
+                .next()
+                .unwrap()
+                .unwrap()
+                .starts_with(&expected_spdx_identifier)
+        } else {
+            first_line.starts_with(&expected_spdx_identifier)
+        }
+    } else {
+        let first_line = lines.next();
+        if let Some(Ok(line)) = first_line {
+            line.starts_with(&expected_spdx_identifier)
+        } else {
+            false
+        }
+    };
+    if ok {
+        println!("Found SPDX identifier in file: {:?}", file_path);
+    } else {
+        eprintln!("Missing SPDX identifier in file: {:?}", file_path);
+    }
+    ok
+}
+
+fn find_missing_spdx_files(root: &Path) -> Vec<PathBuf> {
+    let mut missing_spdx_files = Vec::new();
+    let mut dir_worklist: Vec<PathBuf> = vec![root.into()];
+
+    loop {
+        let dir = match dir_worklist.pop() {
+            Some(dir) => dir,
+            None => break,
+        };
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            if path.is_dir() {
+                // Exclude directories that should not be checked
+                if entry.file_name() != "target"
+                    && entry.file_name() != ".git"
+                    && entry.file_name() != "xlsynth_tools"
+                {
+                    println!("Adding to directory worklist: {:?}", path);
+                    dir_worklist.push(path.clone());
+                }
+                continue;
+            }
+
+            // For golden comparison files (i.e. ones we compare to literally for code
+            // generation facilities) we don't require SPDX identifiers.
+            if path.as_os_str().to_str().unwrap().ends_with(".golden.sv") {
+                continue;
+            }
+
+            if path.file_name().unwrap().to_str().unwrap() == "estimator_model.proto" {
+                continue;
+            }
+
+            if let Some(extension) = path.extension() {
+                if extension == "md"
+                    || extension == "lock"
+                    || extension == "toml"
+                    || extension == "supp"
+                {
+                    continue;
+                }
+                // Check all source files, not just Rust files
+                if !check_spdx_identifier(&path) {
+                    missing_spdx_files.push(path);
+                }
+            }
+        }
+    }
+    missing_spdx_files
+}
+
+#[test]
+fn test_finds_rust_file_missing_spdx_in_tempdir() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir_path = temp_dir.path();
+
+    // Write one file that does have the SPDX identifier.
+    let has_spdx_file = temp_dir_path.join("has_spdx.rs");
+    fs::write(has_spdx_file, "// SPDX-License-Identifier: Apache-2.0\n").unwrap();
+
+    // Write one file that does not have the SPDX identifier.
+    let missing_spdx_file = temp_dir_path.join("missing_spdx.rs");
+    fs::write(missing_spdx_file.clone(), "").unwrap();
+
+    let missing_spdx_files = find_missing_spdx_files(temp_dir_path);
+    assert_eq!(missing_spdx_files.len(), 1);
+    assert!(missing_spdx_files.contains(&missing_spdx_file));
+}
+
+#[test]
+fn check_all_rust_files_for_spdx() {
+    // Use cargo_metadata to get the workspace root
+    let metadata = MetadataCommand::new().exec().unwrap();
+    let workspace_dir = metadata.workspace_root;
+    let missing_spdx_files = find_missing_spdx_files(workspace_dir.as_std_path());
+    assert!(
+        missing_spdx_files.is_empty(),
+        "The following files are missing SPDX identifiers: {:?}",
+        missing_spdx_files
+    );
+}

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test that the current package version reflected in Cargo.toml is more than
+//! the released version -- this help make sure we bump the version
+//! appropriately after a release is performed.
+//!
+//! This is done for all released crates in the workspace.
+
+// from https://github.com/xlsynth/xlsynth-crate/blob/main/test-helpers/tests/version_test.rs
+
+use curl::easy::Easy;
+
+const USER_AGENT: &str = "topstitch_crate_unit_test";
+
+fn get_workspace_root() -> std::path::PathBuf {
+    let workspace_dir = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .unwrap()
+        .workspace_root;
+    workspace_dir.into()
+}
+
+/// Fetches the latest version of a crate named `crate_name` from crates.io.
+fn fetch_latest_version(crate_name: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let url = format!("https://crates.io/api/v1/crates/{}", crate_name);
+    let mut data = Vec::new();
+    let mut easy = Easy::new();
+    easy.url(&url)?;
+    easy.useragent(USER_AGENT)?;
+    {
+        let mut transfer = easy.transfer();
+        transfer.write_function(|new_data| {
+            data.extend_from_slice(new_data);
+            Ok(new_data.len())
+        })?;
+        transfer.perform()?;
+    }
+
+    let response: serde_json::Value = serde_json::from_slice(&data)?;
+    log::debug!("Response: {:?}", response);
+    let newest_version = response["crate"]["newest_version"].as_str();
+    let latest_version = newest_version
+        .ok_or(format!(
+            "Failed to parse latest version: {:?}",
+            newest_version
+        ))?
+        .to_string();
+    Ok(latest_version)
+}
+
+/// Fetches the local version of a package given the path to a `Cargo.toml`
+/// file.
+fn fetch_local_version(dirpath: &std::path::PathBuf) -> Result<String, Box<dyn std::error::Error>> {
+    let cargo_toml = std::fs::read_to_string(dirpath.join("Cargo.toml"))?;
+    let cargo_toml: toml::Value = toml::from_str(&cargo_toml)?;
+    let version = cargo_toml["package"]["version"]
+        .as_str()
+        .ok_or(format!(
+            "Failed to parse local version: {}",
+            cargo_toml["package"]["version"]
+        ))?
+        .to_string();
+    Ok(version)
+}
+
+fn validate_local_version_gt_released(
+    crate_name: &str,
+    workspace_path: &std::path::PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let latest_version = fetch_latest_version(crate_name)?;
+    let local_version = fetch_local_version(workspace_path)?;
+
+    let local_semver = semver::Version::parse(&local_version)?;
+    let latest_semver = semver::Version::parse(&latest_version)?;
+
+    log::info!(
+        "crate: {} local_version: {} released_version: {}",
+        crate_name,
+        local_version,
+        latest_version
+    );
+
+    if local_semver <= latest_semver {
+        // Technically we're abusing io::Error a bit here just to avoid creating a whole
+        // new error type.
+        Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "Local version {} is not greater than the latest version {}",
+                local_version, latest_version
+            ),
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+#[test]
+fn test_topstitch_crate_version() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    validate_local_version_gt_released("topstitch", &get_workspace_root()).unwrap();
+}


### PR DESCRIPTION
These are adapted from [xlsynth-crate](https://github.com/xlsynth/xlsynth-crate) and [bedrock-rtl](https://github.com/xlsynth/bedrock-rtl):
* Automatically publish to [crates.io](https://crates.io) when a `v*` tag is pushed.
* Check to make sure the `Cargo.toml` version is ahead of the crates.io version
* Check to make sure that there is an SPDX license comment at the top of each page
* Run pre-commit checks to catch file formatting issues.