### PR TITLE
Add features for checking abutted connectivity

### DIFF
--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -2,6 +2,7 @@
 
 use indexmap::IndexMap;
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::{Intf, Port, Usage};
@@ -23,6 +24,7 @@ mod stub;
 mod validate;
 mod wrap;
 use parser::parser_port_to_port;
+mod abutment;
 
 /// Represents a module definition, like `module <mod_def_name> ... endmodule`
 /// in Verilog.
@@ -51,6 +53,8 @@ impl ModDef {
                 verilog_import: None,
                 inst_connections: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
+                adjacency_matrix: HashMap::new(),
+                ignore_adjacency: HashSet::new(),
             })),
         }
     }

--- a/src/mod_def/abutment.rs
+++ b/src/mod_def/abutment.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use crate::{ModDef, ModInst, PortSlice};
+
+impl ModDef {
+    pub(crate) fn mark_adjacent(&mut self, inst_a: &ModInst, inst_b: &ModInst) {
+        // Check that the two instances are in this module definition.
+        for inst in [inst_a, inst_b] {
+            assert!(Rc::ptr_eq(&inst.mod_def_core.upgrade().unwrap(), &self.core),
+                "Cannot annotate adjacency property for instance {} because it is not an instance of {}",
+                inst.debug_string(),
+                self.get_name()
+            );
+        }
+
+        // Mark the two instances as adjacent.
+        let mut core = self.core.borrow_mut();
+        for adjacency_pair in [(inst_a, inst_b), (inst_b, inst_a)] {
+            core.adjacency_matrix
+                .entry(adjacency_pair.0.name.clone())
+                .or_default()
+                .insert(adjacency_pair.1.name.clone());
+        }
+    }
+
+    fn should_consider_adjacency(&self, inst_name: impl AsRef<str>) -> bool {
+        !self
+            .core
+            .borrow()
+            .ignore_adjacency
+            .contains(inst_name.as_ref())
+    }
+
+    pub(crate) fn is_non_abutted(
+        &self,
+        port_slice_a: &PortSlice,
+        port_slice_b: &PortSlice,
+    ) -> bool {
+        let mut inst_names = Vec::new();
+        for port_slice in [port_slice_a, port_slice_b] {
+            let inst_name = port_slice
+                .get_inst_name()
+                .ok_or_else(|| {
+                    format!(
+                        "Cannot check abutment for module definition port {}",
+                        port_slice.debug_string()
+                    )
+                })
+                .unwrap();
+            if !self.should_consider_adjacency(&inst_name) {
+                return false; // i.e., we won't be able to definitively say that
+                              // the two ports are non-abutted
+            }
+            inst_names.push(inst_name);
+        }
+
+        !self
+            .core
+            .borrow()
+            .adjacency_matrix
+            .get(&inst_names[0])
+            .unwrap_or(&HashSet::new())
+            .contains(&inst_names[1])
+    }
+
+    /// Returns a vector of all connections that are not known to be abutted,
+    /// excluding connections involving instances that have been marked with
+    /// `ignore_adjacency()`. Each connection returned is a tuple of the form
+    /// `(port_slice_name_a, port_slice_name_b)`, where `port_slice_name_a`
+    /// and `port_slice_name_b` are the names of the port slices involved in
+    /// the non-abutted connection.
+    pub fn find_non_abutted_connections(&self) -> Vec<(String, String)> {
+        let mut result = Vec::new();
+
+        for assignment in self.core.borrow().assignments.iter() {
+            if self.is_non_abutted(&assignment.lhs, &assignment.rhs) {
+                result.push((assignment.lhs.debug_string(), assignment.rhs.debug_string()));
+            }
+        }
+
+        result
+    }
+}

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use indexmap::IndexMap;
@@ -33,4 +33,6 @@ pub struct ModDefCore {
     pub(crate) inst_connections: IndexMap<String, IndexMap<String, Vec<InstConnection>>>,
     pub(crate) reserved_net_definitions: IndexMap<String, Wire>,
     pub(crate) enum_ports: IndexMap<String, String>,
+    pub(crate) adjacency_matrix: HashMap<String, HashSet<String>>,
+    pub(crate) ignore_adjacency: HashSet<String>,
 }

--- a/src/mod_def/parameterize.rs
+++ b/src/mod_def/parameterize.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use xlsynth::vast::{VastFile, VastFileType};
-
 use indexmap::IndexMap;
 use slang_rs::{self, extract_ports, SlangConfig};
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use xlsynth::vast::{VastFile, VastFileType};
 
 use crate::{Usage, IO};
 
@@ -231,6 +231,8 @@ impl ModDef {
                 verilog_import: None,
                 inst_connections: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
+                adjacency_matrix: HashMap::new(),
+                ignore_adjacency: HashSet::new(),
             })),
         }
     }

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
@@ -87,6 +88,8 @@ impl ModDef {
                 }),
                 inst_connections: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
+                adjacency_matrix: HashMap::new(),
+                ignore_adjacency: HashSet::new(),
             })),
         }
     }

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use indexmap::IndexMap;
@@ -36,6 +36,8 @@ impl ModDef {
                 verilog_import: None,
                 inst_connections: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
+                adjacency_matrix: HashMap::new(),
+                ignore_adjacency: HashSet::new(),
             })),
         }
     }

--- a/src/mod_inst.rs
+++ b/src/mod_inst.rs
@@ -125,6 +125,26 @@ impl ModInst {
             self.name
         )
     }
+
+    /// Indicate that this instance is adjacent to another instance for
+    /// the purpose of checking abuted connections.
+    pub fn mark_adjacent_to(&self, other: &ModInst) {
+        ModDef {
+            core: self.mod_def_core.upgrade().unwrap().clone(),
+        }
+        .mark_adjacent(self, other);
+    }
+
+    /// Indicate that this instance should not be considered for abutment
+    /// checking.
+    pub fn ignore_adjacency(&self) {
+        self.mod_def_core
+            .upgrade()
+            .unwrap()
+            .borrow_mut()
+            .ignore_adjacency
+            .insert(self.name.clone());
+    }
 }
 
 impl ConvertibleToModDef for ModInst {

--- a/src/port_slice.rs
+++ b/src/port_slice.rs
@@ -93,6 +93,15 @@ impl PortSlice {
             );
         }
     }
+
+    /// Returns the instance name corresponding to the port slice, if this is
+    /// a port slice on an instance. Otherwise, returns `None`.
+    pub(crate) fn get_inst_name(&self) -> Option<String> {
+        match &self.port {
+            Port::ModInst { inst_name, .. } => Some(inst_name.clone()),
+            _ => None,
+        }
+    }
 }
 
 /// Indicates that a type can be converted to a `PortSlice`. `Port` and

--- a/tests/checks/abutment.rs
+++ b/tests/checks/abutment.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use topstitch::*;
+
+fn new_mod_def(name: &str) -> ModDef {
+    let mod_def = ModDef::new(name);
+    mod_def.add_port("in", IO::Input(8)).unused();
+    mod_def.add_port("out", IO::Output(8)).tieoff(0);
+    mod_def
+}
+
+/// Creates a 1D array of modules with the given names, with the output of one
+/// module connected to the input of the next. If `loopback` is true, the output
+/// of the last module is connected to the input of the first module.
+fn new_top(names: &[&str], loopback: bool) -> (ModDef, Vec<ModInst>) {
+    let top = ModDef::new("Top");
+
+    let insts: Vec<_> = names
+        .iter()
+        .map(|&name| top.instantiate(&new_mod_def(name), None, None))
+        .collect();
+
+    for (k, inst) in insts[1..].iter().enumerate() {
+        inst.get_port("in").connect(&insts[k].get_port("out"));
+        inst.mark_adjacent_to(&insts[k]);
+    }
+
+    if loopback {
+        insts
+            .first()
+            .unwrap()
+            .get_port("in")
+            .connect(&insts.last().unwrap().get_port("out"));
+    } else {
+        insts.first().unwrap().get_port("in").tieoff(0);
+        insts.last().unwrap().get_port("out").unused();
+    }
+
+    (top, insts)
+}
+
+#[test]
+fn test_abutment_check_loopback() {
+    let (top, _insts) = new_top(&["A", "B", "C"], true);
+    assert_eq!(
+        top.find_non_abutted_connections(),
+        vec![(
+            "Top.A_i.in[7:0]".to_string(),
+            "Top.C_i.out[7:0]".to_string()
+        )]
+    );
+}
+
+#[test]
+fn test_abutment_check_no_loopback() {
+    let (top, _insts) = new_top(&["A", "B", "C"], false);
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}
+
+#[test]
+fn test_abutment_check_with_ignore_a() {
+    let (top, insts) = new_top(&["A", "B", "C"], true);
+    insts[0].ignore_adjacency();
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}
+
+#[test]
+fn test_abutment_check_with_ignore_b() {
+    let (top, insts) = new_top(&["A", "B", "C"], true);
+    insts[1].ignore_adjacency();
+    assert_eq!(
+        top.find_non_abutted_connections(),
+        vec![(
+            "Top.A_i.in[7:0]".to_string(),
+            "Top.C_i.out[7:0]".to_string()
+        )]
+    );
+}
+
+#[test]
+fn test_abutment_check_with_ignore_c() {
+    let (top, insts) = new_top(&["A", "B", "C"], true);
+    insts[2].ignore_adjacency();
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}

--- a/tests/checks/mod.rs
+++ b/tests/checks/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod abutment;
 mod unused;
 mod validate;

--- a/tests/spdx_test.rs
+++ b/tests/spdx_test.rs
@@ -55,11 +55,7 @@ fn find_missing_spdx_files(root: &Path) -> Vec<PathBuf> {
     let mut missing_spdx_files = Vec::new();
     let mut dir_worklist: Vec<PathBuf> = vec![root.into()];
 
-    loop {
-        let dir = match dir_worklist.pop() {
-            Some(dir) => dir,
-            None => break,
-        };
+    while let Some(dir) = dir_worklist.pop() {
         for entry in fs::read_dir(dir).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -50,7 +50,7 @@ fn fetch_latest_version(crate_name: &str) -> Result<String, Box<dyn std::error::
 
 /// Fetches the local version of a package given the path to a `Cargo.toml`
 /// file.
-fn fetch_local_version(dirpath: &std::path::PathBuf) -> Result<String, Box<dyn std::error::Error>> {
+fn fetch_local_version(dirpath: &std::path::Path) -> Result<String, Box<dyn std::error::Error>> {
     let cargo_toml = std::fs::read_to_string(dirpath.join("Cargo.toml"))?;
     let cargo_toml: toml::Value = toml::from_str(&cargo_toml)?;
     let version = cargo_toml["package"]["version"]
@@ -65,7 +65,7 @@ fn fetch_local_version(dirpath: &std::path::PathBuf) -> Result<String, Box<dyn s
 
 fn validate_local_version_gt_released(
     crate_name: &str,
-    workspace_path: &std::path::PathBuf,
+    workspace_path: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let latest_version = fetch_latest_version(crate_name)?;
     let local_version = fetch_local_version(workspace_path)?;
@@ -98,5 +98,5 @@ fn validate_local_version_gt_released(
 #[test]
 fn test_topstitch_crate_version() {
     let _ = env_logger::builder().is_test(true).try_init();
-    validate_local_version_gt_released("topstitch", &get_workspace_root()).unwrap();
+    validate_local_version_gt_released("topstitch", get_workspace_root().as_path()).unwrap();
 }


### PR DESCRIPTION
This PR adds a basic feature for checking abutted connectivity. Module instances can be marked as adjacent to other module instances using the new `.mark_adjacent_to(other)` method, and a new method `.find_non_abutted_connections()` for is provided to retrieve a list of all connections within a module definition that cannot be made by abutment according to these annotations. Instances can be excluded from abutment checking with the method `.ignore_adjacency()`.

For now, the only connections analyzed are between module instances within a module definition. In the future, the analysis will be extended to examine connections hierarchically. This change will go well with other updates planned for the internal representation of connections.

Also includes an unrelated change to resolve a few clippy warnings.