### PR TITLE
Fix platform for running publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out code
@@ -53,9 +53,7 @@ jobs:
           ${{ runner.os }}-cargo-index-
 
     - name: Build and test
-      run: |
-        export SLANG_PATH=`realpath slang`
-        cargo test
+      run: export SLANG_PATH=`realpath slang` && cargo test
 
     - name: Publish topstitch to crates.io
       env:


### PR DESCRIPTION
Had been MacOS, but needed to be Ubuntu 24.04 to be compatible with the `slang` binary.