### PR TITLE
Updates to the abutment checking feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/intf/connect.rs
+++ b/src/intf/connect.rs
@@ -16,16 +16,24 @@ impl Intf {
     /// other interface did not, this method would panic unless `allow_mismatch`
     /// was `true`.
     pub fn connect(&self, other: &Intf, allow_mismatch: bool) {
-        self.connect_generic(other, None, allow_mismatch);
+        self.connect_generic(other, None, false, allow_mismatch);
     }
+
+    /// Connects this interface to another interface, assuming that the
+    /// connection is non-abutted.
+    pub fn connect_non_abutted(&self, other: &Intf, allow_mismatch: bool) {
+        self.connect_generic(other, None, true, allow_mismatch);
+    }
+
     pub fn connect_pipeline(&self, other: &Intf, pipeline: PipelineConfig, allow_mismatch: bool) {
-        self.connect_generic(other, Some(pipeline), allow_mismatch);
+        self.connect_generic(other, Some(pipeline), false, allow_mismatch);
     }
 
     pub(crate) fn connect_generic(
         &self,
         other: &Intf,
         pipeline: Option<PipelineConfig>,
+        is_non_abutted: bool,
         allow_mismatch: bool,
     ) {
         let self_ports = self.get_port_slices();
@@ -33,7 +41,7 @@ impl Intf {
 
         for (func_name, self_port) in &self_ports {
             if let Some(other_port) = other_ports.get(func_name) {
-                self_port.connect_generic(other_port, pipeline.clone());
+                self_port.connect_generic(other_port, pipeline.clone(), is_non_abutted);
             } else if !allow_mismatch {
                 panic!(
                     "Interfaces {} and {} have mismatched functions and allow_mismatch is false. Example: function '{}' is present in {} but not in {}.",

--- a/src/intf/crossover.rs
+++ b/src/intf/crossover.rs
@@ -17,7 +17,18 @@ impl Intf {
     /// `data_rx` function on the other interface (mapped to `b_data_rx`), and
     /// vice versa.
     pub fn crossover(&self, other: &Intf, pattern_a: impl AsRef<str>, pattern_b: impl AsRef<str>) {
-        self.crossover_generic(other, pattern_a, pattern_b, None);
+        self.crossover_generic(other, pattern_a, pattern_b, None, false);
+    }
+
+    /// Connects this interface to another interface, assuming that the
+    /// connection is non-abutted.
+    pub fn crossover_non_abutted(
+        &self,
+        other: &Intf,
+        pattern_a: impl AsRef<str>,
+        pattern_b: impl AsRef<str>,
+    ) {
+        self.crossover_generic(other, pattern_a, pattern_b, None, true);
     }
 
     pub fn crossover_pipeline(
@@ -27,7 +38,7 @@ impl Intf {
         pattern_b: impl AsRef<str>,
         pipeline: PipelineConfig,
     ) {
-        self.crossover_generic(other, pattern_a, pattern_b, Some(pipeline));
+        self.crossover_generic(other, pattern_a, pattern_b, Some(pipeline), false);
     }
 
     fn crossover_generic(
@@ -36,14 +47,18 @@ impl Intf {
         pattern_a: impl AsRef<str>,
         pattern_b: impl AsRef<str>,
         pipeline: Option<PipelineConfig>,
+        is_non_abutted: bool,
     ) {
         let x_port_slices = self.get_port_slices();
         let y_port_slices = other.get_port_slices();
 
         for (x_func_name, y_func_name) in find_crossover_matches(self, other, pattern_a, pattern_b)
         {
-            x_port_slices[&x_func_name]
-                .connect_generic(&y_port_slices[&y_func_name], pipeline.clone());
+            x_port_slices[&x_func_name].connect_generic(
+                &y_port_slices[&y_func_name],
+                pipeline.clone(),
+                is_non_abutted,
+            );
         }
     }
 

--- a/src/mod_def/dtypes.rs
+++ b/src/mod_def/dtypes.rs
@@ -15,6 +15,7 @@ pub(crate) struct Assignment {
     pub lhs: PortSlice,
     pub rhs: PortSlice,
     pub pipeline: Option<PipelineConfig>,
+    pub is_non_abutted: bool,
 }
 
 #[derive(Clone)]

--- a/src/mod_def/emit.rs
+++ b/src/mod_def/emit.rs
@@ -354,7 +354,10 @@ since the width of that port is {}. Check the slice indices for this instance po
 
         // Emit assign statements for connections.
         let mut pipeline_inst_names = HashSet::new();
-        for Assignment { lhs, rhs, pipeline } in &core.assignments {
+        for Assignment {
+            lhs, rhs, pipeline, ..
+        } in &core.assignments
+        {
             let lhs_slice = match lhs {
                 PortSlice {
                     port: Port::ModDef { name, .. },

--- a/src/mod_def/feedthrough.rs
+++ b/src/mod_def/feedthrough.rs
@@ -35,6 +35,6 @@ impl ModDef {
     ) {
         let input_port = self.add_port(input_name, IO::Input(width));
         let output_port = self.add_port(output_name, IO::Output(width));
-        input_port.connect_generic(&output_port, pipeline);
+        input_port.connect_generic(&output_port, pipeline, false);
     }
 }

--- a/src/mod_def/validate.rs
+++ b/src/mod_def/validate.rs
@@ -182,6 +182,7 @@ impl ModDef {
             lhs: lhs_slice,
             rhs: rhs_slice,
             pipeline,
+            ..
         } in &self.core.borrow().assignments
         {
             for slice in [&lhs_slice, &rhs_slice] {

--- a/src/port/connect.rs
+++ b/src/port/connect.rs
@@ -10,19 +10,27 @@ impl Port {
 
     /// Connects this port to another port or port slice.
     pub fn connect<T: ConvertibleToPortSlice>(&self, other: &T) {
-        self.connect_generic(other, None);
+        self.connect_generic(other, None, false);
+    }
+
+    /// Connects this port to another port or port slice, assuming that the
+    /// connection is non-abutted.
+    pub fn connect_non_abutted<T: ConvertibleToPortSlice>(&self, other: &T) {
+        self.connect_generic(other, None, true);
     }
 
     pub fn connect_pipeline<T: ConvertibleToPortSlice>(&self, other: &T, pipeline: PipelineConfig) {
-        self.connect_generic(other, Some(pipeline));
+        self.connect_generic(other, Some(pipeline), false);
     }
 
     pub(crate) fn connect_generic<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         pipeline: Option<PipelineConfig>,
+        is_non_abutted: bool,
     ) {
-        self.to_port_slice().connect_generic(other, pipeline);
+        self.to_port_slice()
+            .connect_generic(other, pipeline, is_non_abutted);
     }
 
     /// Punches a sequence of feedthroughs through the specified module

--- a/src/port_slice/connect.rs
+++ b/src/port_slice/connect.rs
@@ -59,17 +59,24 @@ impl PortSlice {
     /// upfront checks to make sure that the connection is valid in terms of
     /// width and directionality. Panics if any of these checks fail.
     pub fn connect<T: ConvertibleToPortSlice>(&self, other: &T) {
-        self.connect_generic(other, None);
+        self.connect_generic(other, None, false);
+    }
+
+    /// Connects this port slice to another port or port slice, assuming that
+    /// the connection is non-abutted.
+    pub fn connect_non_abutted<T: ConvertibleToPortSlice>(&self, other: &T) {
+        self.connect_generic(other, None, true);
     }
 
     pub fn connect_pipeline<T: ConvertibleToPortSlice>(&self, other: &T, pipeline: PipelineConfig) {
-        self.connect_generic(other, Some(pipeline));
+        self.connect_generic(other, Some(pipeline), false);
     }
 
     pub(crate) fn connect_generic<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         pipeline: Option<PipelineConfig>,
+        is_non_abutted: bool,
     ) {
         let other_as_slice = other.to_port_slice();
 
@@ -241,10 +248,12 @@ impl PortSlice {
             }
             let lhs = (*lhs).clone();
             let rhs = (*rhs).clone();
-            mod_def_core
-                .borrow_mut()
-                .assignments
-                .push(Assignment { lhs, rhs, pipeline });
+            mod_def_core.borrow_mut().assignments.push(Assignment {
+                lhs,
+                rhs,
+                pipeline,
+                is_non_abutted,
+            });
         }
     }
 

--- a/src/port_slice/feedthrough.rs
+++ b/src/port_slice/feedthrough.rs
@@ -39,7 +39,7 @@ impl PortSlice {
         let original_port = mod_def_or_mod_inst
             .to_mod_def()
             .add_port(&original, self.port.io().with_width(self.width()));
-        flipped_port.connect_generic(&original_port, pipeline.clone());
+        flipped_port.connect_generic(&original_port, pipeline.clone(), false);
         (
             mod_def_or_mod_inst.get_port(&flipped),
             mod_def_or_mod_inst.get_port(&original),

--- a/tests/checks/abutment.rs
+++ b/tests/checks/abutment.rs
@@ -10,9 +10,8 @@ fn new_mod_def(name: &str) -> ModDef {
 }
 
 /// Creates a 1D array of modules with the given names, with the output of one
-/// module connected to the input of the next. If `loopback` is true, the output
-/// of the last module is connected to the input of the first module.
-fn new_top(names: &[&str], loopback: bool) -> (ModDef, Vec<ModInst>) {
+/// module connected to the input of the next.
+fn new_top(names: &[&str]) -> (ModDef, Vec<ModInst>, Port, Port) {
     let top = ModDef::new("Top");
 
     let insts: Vec<_> = names
@@ -20,28 +19,21 @@ fn new_top(names: &[&str], loopback: bool) -> (ModDef, Vec<ModInst>) {
         .map(|&name| top.instantiate(&new_mod_def(name), None, None))
         .collect();
 
+    let first = insts.first().unwrap().get_port("in");
+    let last = insts.last().unwrap().get_port("out");
+
     for (k, inst) in insts[1..].iter().enumerate() {
         inst.get_port("in").connect(&insts[k].get_port("out"));
         inst.mark_adjacent_to(&insts[k]);
     }
 
-    if loopback {
-        insts
-            .first()
-            .unwrap()
-            .get_port("in")
-            .connect(&insts.last().unwrap().get_port("out"));
-    } else {
-        insts.first().unwrap().get_port("in").tieoff(0);
-        insts.last().unwrap().get_port("out").unused();
-    }
-
-    (top, insts)
+    (top, insts, first, last)
 }
 
 #[test]
 fn test_abutment_check_loopback() {
-    let (top, _insts) = new_top(&["A", "B", "C"], true);
+    let (top, _insts, first, last) = new_top(&["A", "B", "C"]);
+    first.connect(&last);
     assert_eq!(
         top.find_non_abutted_connections(),
         vec![(
@@ -52,21 +44,71 @@ fn test_abutment_check_loopback() {
 }
 
 #[test]
+fn test_abutment_check_loopback_non_abutted() {
+    let (top, _insts, first, last) = new_top(&["A", "B", "C"]);
+    first.connect_non_abutted(&last);
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}
+
+#[test]
+fn test_abutment_check_loopback_non_abutted_bit_by_bit() {
+    let (top, _insts, first, last) = new_top(&["A", "B", "C"]);
+    for i in 0..first.io().width() {
+        first.bit(i).connect_non_abutted(&last.bit(i));
+    }
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}
+
+#[test]
+fn test_abutment_check_loopback_intf() {
+    let (top, insts, _, _) = new_top(&["A", "B", "C"]);
+    let first_inst = insts.first().unwrap();
+    let last_inst = insts.last().unwrap();
+    first_inst.get_mod_def().def_intf_from_prefix("in", "in");
+    last_inst.get_mod_def().def_intf_from_prefix("out", "out");
+    first_inst
+        .get_intf("in")
+        .connect_non_abutted(&last_inst.get_intf("out"), false);
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}
+
+#[test]
+fn test_abutment_check_loopback_crossover() {
+    let (top, insts, _, _) = new_top(&["A", "B", "C"]);
+    let first_inst = insts.first().unwrap();
+    let last_inst = insts.last().unwrap();
+    first_inst
+        .get_mod_def()
+        .def_intf_from_regex("in", "in", "in");
+    last_inst
+        .get_mod_def()
+        .def_intf_from_regex("out", "out", "out");
+    first_inst
+        .get_intf("in")
+        .crossover_non_abutted(&last_inst.get_intf("out"), "in", "out");
+    assert_eq!(top.find_non_abutted_connections(), vec![]);
+}
+
+#[test]
 fn test_abutment_check_no_loopback() {
-    let (top, _insts) = new_top(&["A", "B", "C"], false);
+    let (top, _insts, first, last) = new_top(&["A", "B", "C"]);
+    first.export();
+    last.export();
     assert_eq!(top.find_non_abutted_connections(), vec![]);
 }
 
 #[test]
 fn test_abutment_check_with_ignore_a() {
-    let (top, insts) = new_top(&["A", "B", "C"], true);
+    let (top, insts, first, last) = new_top(&["A", "B", "C"]);
+    first.connect(&last);
     insts[0].ignore_adjacency();
     assert_eq!(top.find_non_abutted_connections(), vec![]);
 }
 
 #[test]
 fn test_abutment_check_with_ignore_b() {
-    let (top, insts) = new_top(&["A", "B", "C"], true);
+    let (top, insts, first, last) = new_top(&["A", "B", "C"]);
+    first.connect(&last);
     insts[1].ignore_adjacency();
     assert_eq!(
         top.find_non_abutted_connections(),
@@ -79,7 +121,8 @@ fn test_abutment_check_with_ignore_b() {
 
 #[test]
 fn test_abutment_check_with_ignore_c() {
-    let (top, insts) = new_top(&["A", "B", "C"], true);
+    let (top, insts, first, last) = new_top(&["A", "B", "C"]);
+    first.connect(&last);
     insts[2].ignore_adjacency();
     assert_eq!(top.find_non_abutted_connections(), vec![]);
 }


### PR DESCRIPTION
* Connections involving `ModDef` ports are skipped, rather than causing an error. This is sensible because adjacency between a `ModDef` and a `ModInst` is not defined. In the future, we can treat these types of connections more accurately by analyzing connections hierarchically.
* `connect` and `crossover` now have `_non_abutted` variants that indicate that certain connections are intended to be non-abutted.