### PR TITLE
Initial support for parsing hierarchies + `package` support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
       - id: destroyed-symlinks
       - id: trailing-whitespace
-        exclude: "^(tests/feedthroughs/pipeline.rs)|(tests/modifications/stub.rs)$"
+        exclude: "^(tests/feedthroughs/pipeline.rs)|(tests/modifications/stub.rs)|(tests/hierarchy.rs)$"
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65422aaa27a4ea676df4f6c3be91f8270b887a0884b4675d3e0789808b5a52"
+checksum = "61b181a53b9c3d27c35908d33c1eb437926a0ee832673af8a1ca3d77332641fb"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/topstitch"
 num-bigint = "0.4.3"
 indexmap = "2.5.0"
 xlsynth = "0.0.73"
-slang-rs = "0.15.0"
+slang-rs = "0.17.0"
 itertools = "0.10"
 regex = "1.11.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,4 +35,10 @@ mod util;
 mod funnel;
 pub use funnel::Funnel;
 
+mod package;
+pub use package::{
+    extract_packages_from_verilog, extract_packages_from_verilog_file,
+    extract_packages_from_verilog_files, extract_packages_with_config,
+};
+
 pub use mod_def::ParserConfig;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,5 @@ mod util;
 
 mod funnel;
 pub use funnel::Funnel;
+
+pub use mod_def::ParserConfig;

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -19,13 +19,15 @@ mod instances;
 mod intf;
 mod parameterize;
 mod parser;
+mod parser_cfg;
+pub use parser_cfg::ParserConfig;
 mod ports;
 mod stub;
 mod validate;
 mod wrap;
 use parser::parser_port_to_port;
 mod abutment;
-
+mod hierarchy;
 /// Represents a module definition, like `module <mod_def_name> ... endmodule`
 /// in Verilog.
 #[derive(Clone)]

--- a/src/mod_def/hierarchy.rs
+++ b/src/mod_def/hierarchy.rs
@@ -30,3 +30,27 @@ pub(crate) fn populate_hierarchy(
         }
     }
 }
+
+impl ModDef {
+    /// Report all instances of this module, descending hierarchically. The
+    /// returned vector contains tuples of (module definition name, module
+    /// instance name).
+    pub fn report_all_instances(&self) -> Vec<(String, String)> {
+        let mut result = Vec::new();
+        report_all_instances_helper(self, &self.get_name(), &mut result);
+        result
+    }
+}
+
+fn report_all_instances_helper(
+    parent: &ModDef,
+    parent_path: &str,
+    result: &mut Vec<(String, String)>,
+) {
+    for child_inst in parent.get_instances().iter() {
+        let full_inst_name = format!("{}.{}", parent_path, child_inst.name());
+        let child_mod_def = child_inst.get_mod_def();
+        report_all_instances_helper(&child_mod_def, &full_inst_name, result);
+        result.push((child_mod_def.get_name().to_string(), full_inst_name));
+    }
+}

--- a/src/mod_def/hierarchy.rs
+++ b/src/mod_def/hierarchy.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ModDef;
+use std::collections::HashMap;
+pub(crate) fn populate_hierarchy(
+    parent: &ModDef,
+    inst: &slang_rs::Instance,
+    memo: &mut HashMap<String, ModDef>,
+) {
+    for child in inst.contents.iter() {
+        let child_def_name = &child.borrow().def_name;
+        let child_inst_name = &child.borrow().inst_name;
+        if let Some(child_mod_def) = memo.get(child_def_name) {
+            parent.instantiate(child_mod_def, Some(child_inst_name), None);
+        } else {
+            let child_mod_def = ModDef::new(child_def_name);
+            parent.instantiate(&child_mod_def, Some(child_inst_name), None);
+            memo.insert(child_def_name.clone(), child_mod_def.clone());
+            populate_hierarchy(&child_mod_def, &child.borrow(), memo);
+        }
+    }
+}

--- a/src/mod_def/hierarchy.rs
+++ b/src/mod_def/hierarchy.rs
@@ -9,12 +9,22 @@ pub(crate) fn populate_hierarchy(
 ) {
     for child in inst.contents.iter() {
         let child_def_name = &child.borrow().def_name;
-        let child_inst_name = &child.borrow().inst_name;
+        let mut child_inst_name = child.borrow().inst_name.clone();
+        let mut child_hier_prefix = child.borrow().hier_prefix.clone();
+        if child_hier_prefix.starts_with(".") {
+            child_hier_prefix = child_hier_prefix[1..].to_string();
+        }
+        if child_hier_prefix.ends_with(".") {
+            child_hier_prefix = child_hier_prefix[..child_hier_prefix.len() - 1].to_string();
+        }
+        if !child_hier_prefix.is_empty() {
+            child_inst_name = format!("{}.{}", child_hier_prefix, &child.borrow().inst_name);
+        }
         if let Some(child_mod_def) = memo.get(child_def_name) {
-            parent.instantiate(child_mod_def, Some(child_inst_name), None);
+            parent.instantiate(child_mod_def, Some(&child_inst_name), None);
         } else {
             let child_mod_def = ModDef::new(child_def_name);
-            parent.instantiate(&child_mod_def, Some(child_inst_name), None);
+            parent.instantiate(&child_mod_def, Some(&child_inst_name), None);
             memo.insert(child_def_name.clone(), child_mod_def.clone());
             populate_hierarchy(&child_mod_def, &child.borrow(), memo);
         }

--- a/src/mod_def/parameterize.rs
+++ b/src/mod_def/parameterize.rs
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use indexmap::IndexMap;
-use slang_rs::{self, extract_ports, SlangConfig};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use xlsynth::vast::{VastFile, VastFileType};
 
-use crate::{Usage, IO};
-
-use crate::mod_def::parser_port_to_port;
-use crate::{ModDef, ModDefCore};
+use crate::{mod_def::parser_port_to_port, ModDef, ModDefCore, ParserConfig, Usage, IO};
 
 impl ModDef {
     /// Returns a new module definition that is a variant of this module
@@ -84,7 +80,7 @@ impl ModDef {
             .map(|(k, v)| (k.as_str(), v.as_str()))
             .collect();
 
-        let cfg = SlangConfig {
+        let cfg = ParserConfig {
             sources: sources.as_slice(),
             incdirs: incdirs.as_slice(),
             parameters: &parameters_with_string_values
@@ -97,7 +93,7 @@ impl ModDef {
             ..Default::default()
         };
 
-        let parser_ports = extract_ports(&cfg, true);
+        let parser_ports = slang_rs::extract_ports(&cfg.to_slang_config(), true);
 
         // Generate a wrapper that sets the parameters to the given values.
         let mut file = VastFile::new(VastFileType::Verilog);

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -138,7 +138,7 @@ impl ModDef {
             ..Default::default()
         };
 
-        Self::from_verilog_using_config(name, &cfg)
+        Self::from_verilog_with_config(name, &cfg)
     }
 
     /// Creates a new module definition from Verilog source code. The `name`
@@ -166,14 +166,14 @@ impl ModDef {
             ..Default::default()
         };
 
-        Self::from_verilog_using_config(name, &cfg)
+        Self::from_verilog_with_config(name, &cfg)
     }
 
     /// Creates a new module definition from Verilog sources. The `name`
     /// parameter is the name of the module to extract from Verilog code, and
     /// `cfg` is a `ParserConfig` struct specifying source files, include
     /// directories, etc.
-    pub fn from_verilog_using_config(name: impl AsRef<str>, cfg: &ParserConfig) -> Self {
+    pub fn from_verilog_with_config(name: impl AsRef<str>, cfg: &ParserConfig) -> Self {
         let value = slang_rs::run_slang(&cfg.to_slang_config()).unwrap();
 
         let parser_ports = slang_rs::extract_ports_from_value(&value, cfg.skip_unsupported);
@@ -204,7 +204,7 @@ impl ModDef {
         }
     }
 
-    pub fn all_from_verilog_using_config(cfg: &ParserConfig) -> Vec<Self> {
+    pub fn all_from_verilog_with_config(cfg: &ParserConfig) -> Vec<Self> {
         let value = slang_rs::run_slang(&cfg.to_slang_config()).unwrap();
         let parser_ports = slang_rs::extract_ports_from_value(&value, cfg.skip_unsupported);
 

--- a/src/mod_def/parser_cfg.rs
+++ b/src/mod_def/parser_cfg.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use slang_rs::SlangConfig;
+
+#[derive(Debug)]
+pub struct ParserConfig<'a> {
+    pub sources: &'a [&'a str],
+    pub tops: &'a [&'a str],
+    pub incdirs: &'a [&'a str],
+    pub defines: &'a [(&'a str, &'a str)],
+    pub parameters: &'a [(&'a str, &'a str)],
+    pub libfiles: &'a [&'a str],
+    pub libdirs: &'a [&'a str],
+    pub libexts: &'a [&'a str],
+    pub ignore_unknown_modules: bool,
+    pub ignore_protected: bool,
+    pub timescale: Option<&'a str>,
+    pub skip_unsupported: bool,
+    pub include_hierarchy: bool,
+}
+
+impl Default for ParserConfig<'_> {
+    fn default() -> Self {
+        ParserConfig {
+            sources: &[],
+            tops: &[],
+            incdirs: &[],
+            defines: &[],
+            parameters: &[],
+            libfiles: &[],
+            libdirs: &[],
+            libexts: &[],
+            ignore_unknown_modules: true,
+            ignore_protected: true,
+            timescale: None,
+            skip_unsupported: false,
+            include_hierarchy: false,
+        }
+    }
+}
+
+impl ParserConfig<'_> {
+    pub fn to_slang_config(&self) -> SlangConfig {
+        SlangConfig {
+            sources: self.sources,
+            tops: self.tops,
+            incdirs: self.incdirs,
+            defines: self.defines,
+            parameters: self.parameters,
+            libfiles: self.libfiles,
+            libdirs: self.libdirs,
+            libexts: self.libexts,
+            ignore_unknown_modules: self.ignore_unknown_modules,
+            ignore_protected: self.ignore_protected,
+            timescale: self.timescale,
+        }
+    }
+}

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ParserConfig;
+use slang_rs::Package;
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+
+pub fn extract_packages_from_verilog_file(
+    verilog: &Path,
+    ignore_unknown_modules: bool,
+) -> Result<HashMap<String, Package>, Box<dyn Error>> {
+    extract_packages_from_verilog_files(&[verilog], ignore_unknown_modules)
+}
+
+pub fn extract_packages_from_verilog_files(
+    verilog: &[&Path],
+    ignore_unknown_modules: bool,
+) -> Result<HashMap<String, Package>, Box<dyn Error>> {
+    let cfg = ParserConfig {
+        sources: &verilog
+            .iter()
+            .map(|path| path.to_str().unwrap())
+            .collect::<Vec<_>>(),
+        ignore_unknown_modules,
+        ..Default::default()
+    };
+
+    extract_packages_with_config(&cfg)
+}
+
+pub fn extract_packages_from_verilog(
+    verilog: impl AsRef<str>,
+    ignore_unknown_modules: bool,
+) -> Result<HashMap<String, Package>, Box<dyn Error>> {
+    let verilog = slang_rs::str2tmpfile(verilog.as_ref()).unwrap();
+
+    let cfg = ParserConfig {
+        sources: &[verilog.path().to_str().unwrap()],
+        ignore_unknown_modules,
+        ..Default::default()
+    };
+
+    extract_packages_with_config(&cfg)
+}
+
+pub fn extract_packages_with_config(
+    cfg: &ParserConfig,
+) -> Result<HashMap<String, Package>, Box<dyn Error>> {
+    slang_rs::extract_packages(&cfg.to_slang_config())
+}

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -9,11 +9,21 @@ fn test_extract_hierarchy() {
         module C;
         endmodule
         module B;
-          C c0();
+          logic genblk1;
+          if (1) begin
+            C c0();
+          end
           C c1();
+          if (0) begin
+            C c2();
+          end
         endmodule
         module A;
-          B b0();
+          for (genvar i=0; i<1; i++) begin : blkX
+            if (1) begin : blkY
+              B b0();
+            end
+          end
         endmodule
         ",
     )
@@ -27,6 +37,9 @@ fn test_extract_hierarchy() {
 
     let result = ModDef::from_verilog_using_config("A", &cfg);
 
+    // TODO: implement the comparison in a cleaner way, since module instance
+    // names with dots may not be permitted by TopStitch in the future.
+
     assert_eq!(
         result.emit(true),
         "\
@@ -34,7 +47,7 @@ module C;
 
 endmodule
 module B;
-  C c0 (
+  C genblk01.c0 (
     
   );
   C c1 (
@@ -42,7 +55,7 @@ module B;
   );
 endmodule
 module A;
-  B b0 (
+  B blkX[0].blkY.b0 (
     
   );
 endmodule

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -39,7 +39,7 @@ fn test_extract_hierarchy() {
         ..Default::default()
     };
 
-    let result = ModDef::from_verilog_using_config("A", &cfg).report_all_instances();
+    let result = ModDef::from_verilog_with_config("A", &cfg).report_all_instances();
 
     assert_eq!(
         result,

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use topstitch::*;
+
+#[test]
+fn test_extract_hierarchy() {
+    let source = slang_rs::str2tmpfile(
+        "
+        module C;
+        endmodule
+        module B;
+          C c0();
+          C c1();
+        endmodule
+        module A;
+          B b0();
+        endmodule
+        ",
+    )
+    .unwrap();
+
+    let cfg = ParserConfig {
+        sources: &[source.path().to_str().unwrap()],
+        include_hierarchy: true,
+        ..Default::default()
+    };
+
+    let result = ModDef::from_verilog_using_config("A", &cfg);
+
+    assert_eq!(
+        result.emit(true),
+        "\
+module C;
+
+endmodule
+module B;
+  C c0 (
+    
+  );
+  C c1 (
+    
+  );
+endmodule
+module A;
+  B b0 (
+    
+  );
+endmodule
+",
+    );
+}

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -18,12 +18,16 @@ fn test_extract_hierarchy() {
             C c2();
           end
         endmodule
+        module D;
+          logic genblk1;
+        endmodule
         module A;
-          for (genvar i=0; i<1; i++) begin : blkX
+          for (genvar i=0; i<2; i++) begin : blkX
             if (1) begin : blkY
               B b0();
             end
           end
+          D d0();
         endmodule
         ",
     )
@@ -35,30 +39,18 @@ fn test_extract_hierarchy() {
         ..Default::default()
     };
 
-    let result = ModDef::from_verilog_using_config("A", &cfg);
-
-    // TODO: implement the comparison in a cleaner way, since module instance
-    // names with dots may not be permitted by TopStitch in the future.
+    let result = ModDef::from_verilog_using_config("A", &cfg).report_all_instances();
 
     assert_eq!(
-        result.emit(true),
-        "\
-module C;
-
-endmodule
-module B;
-  C genblk01.c0 (
-    
-  );
-  C c1 (
-    
-  );
-endmodule
-module A;
-  B blkX[0].blkY.b0 (
-    
-  );
-endmodule
-",
+        result,
+        vec![
+            ("C".to_string(), "A.blkX[0].blkY.b0.genblk01.c0".to_string()),
+            ("C".to_string(), "A.blkX[0].blkY.b0.c1".to_string()),
+            ("B".to_string(), "A.blkX[0].blkY.b0".to_string()),
+            ("C".to_string(), "A.blkX[1].blkY.b0.genblk01.c0".to_string()),
+            ("C".to_string(), "A.blkX[1].blkY.b0.c1".to_string()),
+            ("B".to_string(), "A.blkX[1].blkY.b0".to_string()),
+            ("D".to_string(), "A.d0".to_string()),
+        ]
     );
 }

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use topstitch::*;
+
+#[test]
+fn test_extract_packages() {
+    let verilog = "
+      package pkg_a;
+        localparam int a=22;
+      endpackage
+      package pkg_b;
+        localparam int b=123;
+        localparam int c=b+pkg_a::a;
+        typedef logic [33:22] my_t;
+      endpackage
+    ";
+
+    let pkgs = extract_packages_from_verilog(verilog, false).unwrap();
+
+    assert_eq!(pkgs["pkg_a"]["a"].parse::<i32>().unwrap(), 22);
+    assert_eq!(pkgs["pkg_b"]["b"].parse::<i32>().unwrap(), 123);
+    assert_eq!(pkgs["pkg_b"]["c"].parse::<i32>().unwrap(), 145);
+}

--- a/tests/syntax/import.rs
+++ b/tests/syntax/import.rs
@@ -177,7 +177,7 @@ endmodule
         sources: &[source.path().to_str().unwrap()],
         ..Default::default()
     };
-    let results = ModDef::all_from_verilog_using_config(&cfg);
+    let results = ModDef::all_from_verilog_with_config(&cfg);
 
     let module_names: Vec<String> = results.iter().map(|mod_def| mod_def.get_name()).collect();
     let mut sorted_module_names = module_names.clone();
@@ -203,7 +203,7 @@ endmodule
         sources: &[source.path().to_str().unwrap()],
         ..Default::default()
     };
-    let results = ModDef::all_from_verilog_using_config(&cfg);
+    let results = ModDef::all_from_verilog_with_config(&cfg);
 
     let module_names: Vec<String> = results.iter().map(|mod_def| mod_def.get_name()).collect();
     let mut sorted_module_names = module_names.clone();

--- a/tests/syntax/import.rs
+++ b/tests/syntax/import.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use slang_rs::str2tmpfile;
-use slang_rs::SlangConfig;
 use topstitch::*;
 
 #[test]
@@ -174,11 +173,11 @@ endmodule
     )
     .unwrap();
 
-    let cfg = SlangConfig {
+    let cfg = ParserConfig {
         sources: &[source.path().to_str().unwrap()],
         ..Default::default()
     };
-    let results = ModDef::all_from_verilog_using_slang(&cfg, false);
+    let results = ModDef::all_from_verilog_using_config(&cfg);
 
     let module_names: Vec<String> = results.iter().map(|mod_def| mod_def.get_name()).collect();
     let mut sorted_module_names = module_names.clone();
@@ -200,11 +199,11 @@ endmodule
     )
     .unwrap();
 
-    let cfg = SlangConfig {
+    let cfg = ParserConfig {
         sources: &[source.path().to_str().unwrap()],
         ..Default::default()
     };
-    let results = ModDef::all_from_verilog_using_slang(&cfg, false);
+    let results = ModDef::all_from_verilog_using_config(&cfg);
 
     let module_names: Vec<String> = results.iter().map(|mod_def| mod_def.get_name()).collect();
     let mut sorted_module_names = module_names.clone();

--- a/tests/syntax/params.rs
+++ b/tests/syntax/params.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use slang_rs::str2tmpfile;
-use slang_rs::SlangConfig;
 use topstitch::*;
 
 #[test]
@@ -99,13 +98,13 @@ fn test_parameterize_with_header() {
     ))
     .unwrap();
 
-    let cfg = SlangConfig {
+    let cfg = ParserConfig {
         sources: &[source.path().to_str().unwrap()],
         incdirs: &[header.path().parent().unwrap().to_str().unwrap()],
         parameters: &[],
         ..Default::default()
     };
-    let orig = ModDef::from_verilog_using_slang("MyModule", &cfg, false);
+    let orig = ModDef::from_verilog_using_config("MyModule", &cfg);
     let modified = orig.parameterize(&[("MY_PARAM_B", 34)], Some("MyModifiedModule"), None);
 
     assert_eq!(orig.get_port("a").io().width(), 12);
@@ -132,11 +131,11 @@ fn test_define_with_parameterize() {
     )
     .unwrap();
 
-    let cfg_no_define = SlangConfig {
+    let cfg_no_define = ParserConfig {
         sources: &[source.path().to_str().unwrap()],
         ..Default::default()
     };
-    let orig_no_define = ModDef::from_verilog_using_slang("foo", &cfg_no_define, false);
+    let orig_no_define = ModDef::from_verilog_using_config("foo", &cfg_no_define);
     let parameterized_no_define = orig_no_define.parameterize(&[("N", 8)], None, None);
 
     assert_eq!(
@@ -154,12 +153,12 @@ endmodule
 "
     );
 
-    let cfg_with_define = SlangConfig {
+    let cfg_with_define = ParserConfig {
         sources: &[source.path().to_str().unwrap()],
         defines: &[("BAR", "1")],
         ..Default::default()
     };
-    let orig_with_define = ModDef::from_verilog_using_slang("foo", &cfg_with_define, false);
+    let orig_with_define = ModDef::from_verilog_using_config("foo", &cfg_with_define);
     let parameterized_with_define = orig_with_define.parameterize(&[("N", 8)], None, None);
 
     assert_eq!(

--- a/tests/syntax/params.rs
+++ b/tests/syntax/params.rs
@@ -104,7 +104,7 @@ fn test_parameterize_with_header() {
         parameters: &[],
         ..Default::default()
     };
-    let orig = ModDef::from_verilog_using_config("MyModule", &cfg);
+    let orig = ModDef::from_verilog_with_config("MyModule", &cfg);
     let modified = orig.parameterize(&[("MY_PARAM_B", 34)], Some("MyModifiedModule"), None);
 
     assert_eq!(orig.get_port("a").io().width(), 12);
@@ -135,7 +135,7 @@ fn test_define_with_parameterize() {
         sources: &[source.path().to_str().unwrap()],
         ..Default::default()
     };
-    let orig_no_define = ModDef::from_verilog_using_config("foo", &cfg_no_define);
+    let orig_no_define = ModDef::from_verilog_with_config("foo", &cfg_no_define);
     let parameterized_no_define = orig_no_define.parameterize(&[("N", 8)], None, None);
 
     assert_eq!(
@@ -158,7 +158,7 @@ endmodule
         defines: &[("BAR", "1")],
         ..Default::default()
     };
-    let orig_with_define = ModDef::from_verilog_using_config("foo", &cfg_with_define);
+    let orig_with_define = ModDef::from_verilog_with_config("foo", &cfg_with_define);
     let parameterized_with_define = orig_with_define.parameterize(&[("N", 8)], None, None);
 
     assert_eq!(


### PR DESCRIPTION
To parse hierarchical contents when importing Verilog, set `include_hierarchy=true` in `ParserConfig`. The `ModDef` returned by TopStitch will then contain module instances, the module definitions for those instances will in turn contain module instances, etc. as far down as the real Verilog hierarchy goes. A convenience method `ModDef.report_all_instances` is provided that returns a vector of definition name / instance name tuples that can be used in downstream processing. More customized processing can always be implemented by working with `ModDef` and `ModInst` structs directly.

SystemVerilog `package` support is provided with the `extract_packages_*` functions; all return a mapping that can be used to retrieve parameter values by package name and parameter name.

To support these changes, `SlangConfig` is replaced with a slightly more general `ParserConfig`. This is intended to provide a place where parsing configuration options can be added in the future without changing function signatures, and decouples the TopStitch parsing configuration from `slang_rs`.