### PR TITLE
Remove caching from hierarchy extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/mod_def/hierarchy.rs
+++ b/src/mod_def/hierarchy.rs
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ModDef;
-use std::collections::HashMap;
-pub(crate) fn populate_hierarchy(
-    parent: &ModDef,
-    inst: &slang_rs::Instance,
-    memo: &mut HashMap<String, ModDef>,
-) {
+pub(crate) fn populate_hierarchy(parent: &ModDef, inst: &slang_rs::Instance) {
     for child in inst.contents.iter() {
         let child_def_name = &child.borrow().def_name;
         let mut child_inst_name = child.borrow().inst_name.clone();
@@ -20,14 +15,9 @@ pub(crate) fn populate_hierarchy(
         if !child_hier_prefix.is_empty() {
             child_inst_name = format!("{}.{}", child_hier_prefix, &child.borrow().inst_name);
         }
-        if let Some(child_mod_def) = memo.get(child_def_name) {
-            parent.instantiate(child_mod_def, Some(&child_inst_name), None);
-        } else {
-            let child_mod_def = ModDef::new(child_def_name);
-            parent.instantiate(&child_mod_def, Some(&child_inst_name), None);
-            memo.insert(child_def_name.clone(), child_mod_def.clone());
-            populate_hierarchy(&child_mod_def, &child.borrow(), memo);
-        }
+        let child_mod_def = ModDef::new(child_def_name);
+        parent.instantiate(&child_mod_def, Some(&child_inst_name), None);
+        populate_hierarchy(&child_mod_def, &child.borrow());
     }
 }
 

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -191,12 +191,7 @@ impl ModDef {
             let mod_def_with_hierarchy = mod_def.stub(&name);
             let hierarchy = slang_rs::extract_hierarchy_from_value(&value);
             if let Some(inst) = hierarchy.get(name.as_ref()) {
-                let mut memo = HashMap::new();
-                crate::mod_def::hierarchy::populate_hierarchy(
-                    &mod_def_with_hierarchy,
-                    inst,
-                    &mut memo,
-                );
+                crate::mod_def::hierarchy::populate_hierarchy(&mod_def_with_hierarchy, inst);
             }
             mod_def_with_hierarchy
         } else {
@@ -216,16 +211,11 @@ impl ModDef {
         if cfg.include_hierarchy {
             let mut mod_defs_with_hierarchy = Vec::new();
             let hierarchy = slang_rs::extract_hierarchy_from_value(&value);
-            let mut memo = HashMap::new();
             for mod_def in mod_defs.iter() {
                 let mod_def_name = mod_def.get_name();
                 if let Some(inst) = hierarchy.get(&mod_def_name) {
                     let stubbed_mod_def = mod_def.stub(&mod_def_name);
-                    crate::mod_def::hierarchy::populate_hierarchy(
-                        &stubbed_mod_def,
-                        inst,
-                        &mut memo,
-                    );
+                    crate::mod_def::hierarchy::populate_hierarchy(&stubbed_mod_def, inst);
                     mod_defs_with_hierarchy.push(stubbed_mod_def);
                 }
             }


### PR DESCRIPTION
This was problematic because it meant that different parameterizations of the same module had the same hierarchy, which is not always the case. Could revisit caching in the future as a performance optimization.