### PR TITLE
Mechanism for parsing typedef widths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721e227e81c968cb3f66be9a0ad2b133f57afbb82b38536b879e287f329dc308"
+checksum = "e2c93bc115aa38318789be45cb4027f23233cbff3f6659843cb27d129789ac46"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/topstitch"
 num-bigint = "0.4.3"
 indexmap = "2.5.0"
 xlsynth = "0.0.73"
-slang-rs = "0.19.0"
+slang-rs = "0.20.0"
 itertools = "0.10"
 regex = "1.11.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use funnel::Funnel;
 mod package;
 pub use package::{
     extract_packages_from_verilog, extract_packages_from_verilog_file,
-    extract_packages_from_verilog_files, extract_packages_with_config,
+    extract_packages_from_verilog_files, extract_packages_with_config, Package, Parameter,
 };
 
 pub use mod_def::ParserConfig;

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ParserConfig;
-use slang_rs::Package;
 use std::collections::HashMap;
 use std::error::Error;
+use std::ops::Index;
 use std::path::Path;
+use std::str::FromStr;
 
 pub fn extract_packages_from_verilog_file(
     verilog: &Path,
@@ -47,5 +48,106 @@ pub fn extract_packages_from_verilog(
 pub fn extract_packages_with_config(
     cfg: &ParserConfig,
 ) -> Result<HashMap<String, Package>, Box<dyn Error>> {
-    slang_rs::extract_packages(&cfg.to_slang_config())
+    let pkgs = slang_rs::extract_packages(&cfg.to_slang_config())?;
+
+    Ok(pkgs
+        .into_iter()
+        .map(|(name, pkg)| {
+            (
+                name.clone(),
+                Package {
+                    name: name.clone(),
+                    parameters: pkg
+                        .parameters
+                        .into_iter()
+                        .map(|(name, param)| {
+                            (
+                                name.clone(),
+                                Parameter {
+                                    name: name.clone(),
+                                    value: param.value,
+                                },
+                            )
+                        })
+                        .collect(),
+                },
+            )
+        })
+        .collect())
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Parameter {
+    pub name: String,
+    pub value: String,
+}
+
+impl Parameter {
+    /// Parse the parameter's `value` into any type that implements [`FromStr`].
+    ///
+    /// # Type Parameters
+    ///
+    /// * **`T`** – The numeric type you want (`i64`, `u128`,
+    ///   [`num_bigint::BigInt`], [`num_bigint::BigUint`], `f64`, ...). `T` only
+    ///   needs to satisfy `T: FromStr`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(T::Err)` if `value` is *not* a valid textual
+    /// representation for `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_bigint::{BigInt, BigUint};
+    /// use std::convert::TryFrom;
+    ///
+    /// # use topstitch::Parameter;
+    /// let p = Parameter { name: "answer".into(), value: "42".into() };
+    ///
+    /// // Primitive integer (type inferred)
+    /// let n: i32 = p.parse().unwrap();
+    ///
+    /// // Explicit turbofish when inference can’t decide
+    /// let n128 = p.parse::<u128>().unwrap();
+    ///
+    /// // Big integers
+    /// let big:  BigInt  = p.parse().unwrap();
+    /// let ubig: BigUint = p.parse().unwrap();
+    /// ```
+    pub fn parse<T>(&self) -> Result<T, T::Err>
+    where
+        T: FromStr,
+    {
+        self.value.parse()
+    }
+
+    pub fn calc_type_width(&self) -> Result<usize, Box<dyn Error>> {
+        let value = self.parse::<String>()?;
+        match slang_rs::parse_type_definition(&value)?.width() {
+            Ok(width) => Ok(width),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Package {
+    pub name: String,
+    pub parameters: HashMap<String, Parameter>,
+}
+
+impl Index<&str> for Package {
+    type Output = Parameter;
+
+    fn index(&self, key: &str) -> &Self::Output {
+        &self.parameters[key]
+    }
+}
+
+impl Package {
+    /// Get a parameter from the package, returning `None` if it doesn't exist.
+    pub fn get(&self, key: &str) -> Option<&Parameter> {
+        self.parameters.get(key)
+    }
 }

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -20,4 +20,30 @@ fn test_extract_packages() {
     assert_eq!(pkgs["pkg_a"]["a"].parse::<i32>().unwrap(), 22);
     assert_eq!(pkgs["pkg_b"]["b"].parse::<i32>().unwrap(), 123);
     assert_eq!(pkgs["pkg_b"]["c"].parse::<i32>().unwrap(), 145);
+    assert_eq!(pkgs["pkg_b"]["my_t"].calc_type_width().unwrap(), 12);
+}
+
+#[test]
+fn test_extract_packages_with_typedefs() {
+    let verilog = "
+      package my_pkg;
+        typedef struct packed {
+          logic [2:0] a;
+          logic [1:0] b;
+          logic c;
+        } my_struct_t;
+        typedef enum logic [1:0] {
+          Red = 0,
+          Green = 1,
+          Blue = 2
+        } my_enum_t;
+        typedef my_struct_t [3:0] my_array_t;
+      endpackage
+    ";
+
+    let pkgs = extract_packages_from_verilog(verilog, false).unwrap();
+
+    assert_eq!(pkgs["my_pkg"]["my_struct_t"].calc_type_width().unwrap(), 6);
+    assert_eq!(pkgs["my_pkg"]["my_enum_t"].calc_type_width().unwrap(), 2);
+    assert_eq!(pkgs["my_pkg"]["my_array_t"].calc_type_width().unwrap(), 24);
 }


### PR DESCRIPTION
Package parameters now have a `calc_type_width` method that returns the width of a typedef, such as `logic [33:22]` or more complex types including packed arrays, structs, enums.