### PR TITLE
Update mechanism for working with remaining funnel capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/tests/feedthroughs/funnel.rs
+++ b/tests/feedthroughs/funnel.rs
@@ -53,13 +53,10 @@ fn test_funnel() {
         &c_inst.get_port("c_ready_out"),
     );
 
-    assert_eq!(funnel.a_to_b_remaining(), 1);
-    assert_eq!(funnel.b_to_a_remaining(), 9);
+    funnel.tieoff_remaining();
 
-    funnel.done();
-
-    assert_eq!(funnel.a_to_b_remaining(), 0);
-    assert_eq!(funnel.b_to_a_remaining(), 0);
+    assert!(funnel.a2b_yield_remaining().is_none());
+    assert!(funnel.b2a_yield_remaining().is_none());
 
     assert_eq!(
         top_module.emit(true),
@@ -249,11 +246,8 @@ fn test_funnel_connect_intf() {
 
     funnel.connect_intf(&a_inst.get_intf("a"), &c_inst.get_intf("c"), false);
 
-    funnel.assert_a_to_b_full();
-    assert_eq!(funnel.b_to_a_remaining(), 8);
-
-    funnel.done();
-
+    funnel.assert_a2b_full();
+    funnel.tieoff_remaining();
     funnel.assert_full();
 
     assert_eq!(
@@ -354,11 +348,8 @@ fn test_funnel_crossover_intf() {
         "(.*)_in",
     );
 
-    assert_eq!(funnel.a_to_b_remaining(), 1);
-    funnel.assert_b_to_a_full();
-
-    funnel.done();
-
+    funnel.assert_b2a_full();
+    funnel.tieoff_remaining();
     funnel.assert_full();
 
     assert_eq!(


### PR DESCRIPTION
Adds new functions `a2b_yield_remaining` and `b2a_yield_remaining`; gives `done` the more descriptive name `tieoff_remaining`. In the future, this "yield" mechanism could be generalized to yield a certain number of bits or error out, avoiding a duplication of logic.