### PR TITLE
Allow ModDef::parameterize to take values larger than 32 bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c93bc115aa38318789be45cb4027f23233cbff3f6659843cb27d129789ac46"
+checksum = "3c94a0406f03d903f5e8d66baa6109a89814f2ce5b48ccd81b0ad224b078a42b"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/topstitch"
 num-bigint = "0.4.3"
 indexmap = "2.5.0"
 xlsynth = "0.0.73"
-slang-rs = "0.20.0"
+slang-rs = "0.21.0"
 itertools = "0.10"
 regex = "1.11.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use port_slice::{ConvertibleToPortSlice, PortSlice};
 
 mod mod_def;
 use mod_def::ModDefCore;
+pub use mod_def::ParameterType;
 pub use mod_def::{ConvertibleToModDef, ModDef};
 
 mod usage;

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -18,6 +18,7 @@ mod feedthrough;
 mod instances;
 mod intf;
 mod parameterize;
+pub use parameterize::ParameterType;
 mod parser;
 mod parser_cfg;
 pub use parser_cfg::ParserConfig;
@@ -41,6 +42,7 @@ impl ModDef {
         ModDef {
             core: Rc::new(RefCell::new(ModDefCore {
                 name: name.as_ref().to_string(),
+                parameters: IndexMap::new(),
                 ports: IndexMap::new(),
                 enum_ports: IndexMap::new(),
                 interfaces: IndexMap::new(),

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 use num_bigint::BigInt;
 
 use crate::mod_def::dtypes::VerilogImport;
+use crate::mod_def::ParameterType;
 
 pub(crate) use crate::mod_def::{Assignment, InstConnection, Wire};
 use crate::{PortSlice, Usage, IO};
@@ -19,6 +20,7 @@ use crate::{PortSlice, Usage, IO};
 /// this struct.
 pub struct ModDefCore {
     pub(crate) name: String,
+    pub(crate) parameters: IndexMap<String, ParameterType>,
     pub(crate) ports: IndexMap<String, IO>,
     pub(crate) interfaces: IndexMap<String, IndexMap<String, (String, usize, usize)>>,
     pub(crate) instances: IndexMap<String, Rc<RefCell<ModDefCore>>>,

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -47,7 +47,7 @@ pub(crate) fn parser_param_to_param(
                 ParameterType::Unsigned(width)
             };
             Ok((parser_param.name.clone(), param_type))
-        },
+        }
         _ => {
             // TODO(zhemao): Proper support for struct, union, and enum types
             // For now, we can just treat them as flat unsigned integers

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 
 use crate::mod_def::dtypes::VerilogImport;
 use crate::mod_def::parser_cfg::ParserConfig;
+use crate::mod_def::ParameterType;
 use crate::{ModDef, ModDefCore, Usage, IO};
 
 pub(crate) fn parser_port_to_port(parser_port: &slang_rs::Port) -> Result<(String, IO), String> {
@@ -22,14 +23,66 @@ pub(crate) fn parser_port_to_port(parser_port: &slang_rs::Port) -> Result<(Strin
     }
 }
 
+pub(crate) fn parser_param_to_param(
+    parser_param: &slang_rs::ParameterDef,
+) -> Result<(String, ParameterType), String> {
+    match &parser_param.ty {
+        slang_rs::Type::Logic {
+            signed,
+            unpacked_dimensions,
+            packed_dimensions,
+        } => {
+            if !unpacked_dimensions.is_empty() {
+                return Err(
+                    "Parameters with unpacked dimensions are not currently supported".to_string(),
+                );
+            }
+            let width = parser_param.ty.width()?;
+            // Packed arrays of signed integers should be treated as unsigned
+            // TODO(zhemao): Proper support for packed array types
+            let is_array = packed_dimensions.len() > 1;
+            let param_type = if *signed && !is_array {
+                ParameterType::Signed(width)
+            } else {
+                ParameterType::Unsigned(width)
+            };
+            Ok((parser_param.name.clone(), param_type))
+        },
+        _ => {
+            // TODO(zhemao): Proper support for struct, union, and enum types
+            // For now, we can just treat them as flat unsigned integers
+            let width = parser_param.ty.width()?;
+            Ok((parser_param.name.clone(), ParameterType::Unsigned(width)))
+        }
+    }
+}
+
 impl ModDef {
-    fn mod_def_from_parser_ports(
+    fn mod_def_from_parser_params_and_ports(
         mod_def_name: &str,
+        parser_params: &[slang_rs::ParameterDef],
         parser_ports: &[slang_rs::Port],
         cfg: &ParserConfig,
     ) -> ModDef {
         let mut ports = IndexMap::new();
         let mut enum_ports = IndexMap::new();
+        let mut parameters = IndexMap::new();
+
+        for parser_param in parser_params {
+            match parser_param_to_param(parser_param) {
+                Ok((name, param_type)) => {
+                    parameters.insert(name, param_type);
+                }
+                Err(e) => {
+                    if !cfg.skip_unsupported {
+                        panic!("{e}");
+                    } else {
+                        continue;
+                    }
+                }
+            }
+        }
+
         for parser_port in parser_ports {
             match parser_port_to_port(parser_port) {
                 Ok((name, io)) => {
@@ -63,6 +116,7 @@ impl ModDef {
         ModDef {
             core: Rc::new(RefCell::new(ModDefCore {
                 name: mod_def_name.to_string(),
+                parameters,
                 ports,
                 enum_ports,
                 interfaces: IndexMap::new(),
@@ -176,16 +230,29 @@ impl ModDef {
     pub fn from_verilog_with_config(name: impl AsRef<str>, cfg: &ParserConfig) -> Self {
         let value = slang_rs::run_slang(&cfg.to_slang_config()).unwrap();
 
+        let parser_params =
+            slang_rs::extract_parameter_defs_from_value(&value, cfg.skip_unsupported);
         let parser_ports = slang_rs::extract_ports_from_value(&value, cfg.skip_unsupported);
 
-        let selected = parser_ports.get(name.as_ref()).unwrap_or_else(|| {
+        let selected_params = parser_params.get(name.as_ref()).unwrap_or_else(|| {
+            panic!(
+                "Module definition '{}' not found in Verilog sources.",
+                name.as_ref()
+            )
+        });
+        let selected_ports = parser_ports.get(name.as_ref()).unwrap_or_else(|| {
             panic!(
                 "Module definition '{}' not found in Verilog sources.",
                 name.as_ref()
             )
         });
 
-        let mod_def = Self::mod_def_from_parser_ports(name.as_ref(), selected, cfg);
+        let mod_def = Self::mod_def_from_parser_params_and_ports(
+            name.as_ref(),
+            selected_params,
+            selected_ports,
+            cfg,
+        );
 
         if cfg.include_hierarchy {
             let mod_def_with_hierarchy = mod_def.stub(&name);
@@ -201,11 +268,20 @@ impl ModDef {
 
     pub fn all_from_verilog_with_config(cfg: &ParserConfig) -> Vec<Self> {
         let value = slang_rs::run_slang(&cfg.to_slang_config()).unwrap();
+        let parser_params =
+            slang_rs::extract_parameter_defs_from_value(&value, cfg.skip_unsupported);
         let parser_ports = slang_rs::extract_ports_from_value(&value, cfg.skip_unsupported);
 
         let mod_defs: Vec<ModDef> = parser_ports
             .keys()
-            .map(|name| Self::mod_def_from_parser_ports(name, &parser_ports[name], cfg))
+            .map(|name| {
+                Self::mod_def_from_parser_params_and_ports(
+                    name,
+                    &parser_params[name],
+                    &parser_ports[name],
+                    cfg,
+                )
+            })
             .collect();
 
         if cfg.include_hierarchy {

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -18,6 +18,7 @@ impl ModDef {
         ModDef {
             core: Rc::new(RefCell::new(ModDefCore {
                 name: name.as_ref().to_string(),
+                parameters: core.parameters.clone(),
                 ports: core.ports.clone(),
                 // TODO(sherbst): 12/08/2024 should enum_ports be copied when stubbing?
                 // The implication is that modules that instantiate this stub will


### PR DESCRIPTION
This pulls in changes from slang-rs that lets us extract parameter definitions from the SV file. Add a 'parameters' member to the module definition that keeps the parameter definitions. Then, when parameterizing, check these definitions to determine the width of the literals that should be passed to slang and xlsynth.