### PR TITLE
Allow ModDef::parameterize to take values larger than 32 bits

### DIFF
--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -47,7 +47,7 @@ pub(crate) fn parser_param_to_param(
                 ParameterType::Unsigned(width)
             };
             Ok((parser_param.name.clone(), param_type))
-        },
+        }
         _ => {
             // TODO(zhemao): Proper support for struct, union, and enum types
             // For now, we can just treat them as flat unsigned integers


### PR DESCRIPTION
This pulls in changes from slang-rs that lets us extract parameter
definitions from the SV file. Add a 'parameters' member to the module
definition that keeps the parameter definitions. Then, when
parameterizing, check these definitions to determine the width of the
literals that should be passed to slang and xlsynth.