### PR TITLE
Fix handling of parameters with dependent widths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.62.0"
+version = "0.62.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -26,7 +26,7 @@ mod ports;
 mod stub;
 mod validate;
 mod wrap;
-use parser::parser_port_to_port;
+use parser::{parser_param_to_param, parser_port_to_port};
 mod abutment;
 mod hierarchy;
 /// Represents a module definition, like `module <mod_def_name> ... endmodule`
@@ -42,7 +42,6 @@ impl ModDef {
         ModDef {
             core: Rc::new(RefCell::new(ModDefCore {
                 name: name.as_ref().to_string(),
-                parameters: IndexMap::new(),
                 ports: IndexMap::new(),
                 enum_ports: IndexMap::new(),
                 interfaces: IndexMap::new(),

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -8,7 +8,6 @@ use indexmap::IndexMap;
 use num_bigint::BigInt;
 
 use crate::mod_def::dtypes::VerilogImport;
-use crate::mod_def::ParameterType;
 
 pub(crate) use crate::mod_def::{Assignment, InstConnection, Wire};
 use crate::{PortSlice, Usage, IO};
@@ -20,7 +19,6 @@ use crate::{PortSlice, Usage, IO};
 /// this struct.
 pub struct ModDefCore {
     pub(crate) name: String,
-    pub(crate) parameters: IndexMap<String, ParameterType>,
     pub(crate) ports: IndexMap<String, IO>,
     pub(crate) interfaces: IndexMap<String, IndexMap<String, (String, usize, usize)>>,
     pub(crate) instances: IndexMap<String, Rc<RefCell<ModDefCore>>>,

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -58,30 +58,13 @@ pub(crate) fn parser_param_to_param(
 }
 
 impl ModDef {
-    fn mod_def_from_parser_params_and_ports(
+    fn mod_def_from_parser_ports(
         mod_def_name: &str,
-        parser_params: &[slang_rs::ParameterDef],
         parser_ports: &[slang_rs::Port],
         cfg: &ParserConfig,
     ) -> ModDef {
         let mut ports = IndexMap::new();
         let mut enum_ports = IndexMap::new();
-        let mut parameters = IndexMap::new();
-
-        for parser_param in parser_params {
-            match parser_param_to_param(parser_param) {
-                Ok((name, param_type)) => {
-                    parameters.insert(name, param_type);
-                }
-                Err(e) => {
-                    if !cfg.skip_unsupported {
-                        panic!("{e}");
-                    } else {
-                        continue;
-                    }
-                }
-            }
-        }
 
         for parser_port in parser_ports {
             match parser_port_to_port(parser_port) {
@@ -116,7 +99,6 @@ impl ModDef {
         ModDef {
             core: Rc::new(RefCell::new(ModDefCore {
                 name: mod_def_name.to_string(),
-                parameters,
                 ports,
                 enum_ports,
                 interfaces: IndexMap::new(),
@@ -229,17 +211,8 @@ impl ModDef {
     /// directories, etc.
     pub fn from_verilog_with_config(name: impl AsRef<str>, cfg: &ParserConfig) -> Self {
         let value = slang_rs::run_slang(&cfg.to_slang_config()).unwrap();
-
-        let parser_params =
-            slang_rs::extract_parameter_defs_from_value(&value, cfg.skip_unsupported);
         let parser_ports = slang_rs::extract_ports_from_value(&value, cfg.skip_unsupported);
 
-        let selected_params = parser_params.get(name.as_ref()).unwrap_or_else(|| {
-            panic!(
-                "Module definition '{}' not found in Verilog sources.",
-                name.as_ref()
-            )
-        });
         let selected_ports = parser_ports.get(name.as_ref()).unwrap_or_else(|| {
             panic!(
                 "Module definition '{}' not found in Verilog sources.",
@@ -247,12 +220,7 @@ impl ModDef {
             )
         });
 
-        let mod_def = Self::mod_def_from_parser_params_and_ports(
-            name.as_ref(),
-            selected_params,
-            selected_ports,
-            cfg,
-        );
+        let mod_def = Self::mod_def_from_parser_ports(name.as_ref(), selected_ports, cfg);
 
         if cfg.include_hierarchy {
             let mod_def_with_hierarchy = mod_def.stub(&name);
@@ -268,20 +236,11 @@ impl ModDef {
 
     pub fn all_from_verilog_with_config(cfg: &ParserConfig) -> Vec<Self> {
         let value = slang_rs::run_slang(&cfg.to_slang_config()).unwrap();
-        let parser_params =
-            slang_rs::extract_parameter_defs_from_value(&value, cfg.skip_unsupported);
         let parser_ports = slang_rs::extract_ports_from_value(&value, cfg.skip_unsupported);
 
         let mod_defs: Vec<ModDef> = parser_ports
             .keys()
-            .map(|name| {
-                Self::mod_def_from_parser_params_and_ports(
-                    name,
-                    &parser_params[name],
-                    &parser_ports[name],
-                    cfg,
-                )
-            })
+            .map(|name| Self::mod_def_from_parser_ports(name, &parser_ports[name], cfg))
             .collect();
 
         if cfg.include_hierarchy {

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -18,7 +18,6 @@ impl ModDef {
         ModDef {
             core: Rc::new(RefCell::new(ModDefCore {
                 name: name.as_ref().to_string(),
-                parameters: core.parameters.clone(),
                 ports: core.ports.clone(),
                 // TODO(sherbst): 12/08/2024 should enum_ports be copied when stubbing?
                 // The implication is that modules that instantiate this stub will

--- a/tests/syntax/params.rs
+++ b/tests/syntax/params.rs
@@ -231,3 +231,66 @@ endmodule
         )
     );
 }
+
+#[test]
+fn test_dependent_param_width() {
+    let source = str2tmpfile(
+        "
+          module bigcounter #(
+            parameter int MaxCountWidth = 32,
+            parameter logic [MaxCountWidth-1:0] MaxCount = 1,
+            localparam int CountWidth = $clog2(MaxCount + 1)
+          ) (
+            input logic clk,
+            input logic rst,
+            input logic incr,
+            output logic [CountWidth-1:0] count
+          );
+            always_ff @(posedge clk) begin
+              if (rst) begin
+                count <= '0;
+              end else begin
+                count <= count + incr;
+              end
+            end
+          endmodule
+        ",
+    )
+    .unwrap();
+
+    let base = ModDef::from_verilog_file("bigcounter", source.path(), true, false);
+    let max_count_width = BigInt::from(64);
+    let max_count: BigInt = BigInt::from(2).pow(63) - 1;
+    let modified = base.parameterize(
+        &[
+            ("MaxCountWidth", max_count_width),
+            ("MaxCount", max_count.clone()),
+        ],
+        None,
+        None,
+    );
+    assert_eq!(
+        modified.emit(true),
+        format!(
+            "\
+module bigcounter_MaxCountWidth_64_MaxCount_{max_count}(
+  input wire clk,
+  input wire rst,
+  input wire incr,
+  output wire [62:0] count
+);
+  bigcounter #(
+    .MaxCountWidth(32'h0000_0040),
+    .MaxCount(64'h7fff_ffff_ffff_ffff)
+  ) bigcounter_i (
+    .clk(clk),
+    .rst(rst),
+    .incr(incr),
+    .count(count)
+  );
+endmodule
+",
+            max_count = max_count
+        )
+    );
+}


### PR DESCRIPTION
The previous way of handling parameters would have an issue if the width
of one parameter depended on another, since the parameter types were
only parsed during loading of the original unparameterized module.
Remove the parameters field from ModDefCore and instead derive
the parameter types on demand when the module is re-parsed
with the new parameter values.

---

**Stack**:
- #96
- #95 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*