### PR TITLE
Basic features for placement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +919,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,11 +972,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -1012,6 +1066,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1389,6 +1449,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.62.1"
+version = "0.63.0"
 dependencies = [
  "cargo_metadata",
  "curl",
@@ -1630,6 +1702,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "log",
+ "nalgebra",
  "num-bigint",
  "regex",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.62.1"
+version = "0.63.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -15,6 +15,7 @@ xlsynth = "0.0.73"
 slang-rs = "0.21.0"
 itertools = "0.10"
 regex = "1.11.0"
+nalgebra = { version = "0.32", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 cargo_metadata = "0.18"

--- a/src/lefdef.rs
+++ b/src/lefdef.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::Path;
+
+use crate::Orientation;
+
+/// Options that affect both LEF and DEF generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LefDefOptions {
+    /// Hierarchy separator. Default: "/".
+    pub divider_char: String,
+    /// Bus bit characters. Default: "[]".
+    pub bus_bit_chars: String,
+    /// Micron database units. Default: 1.
+    pub units_microns: i64,
+}
+
+impl Default for LefDefOptions {
+    fn default() -> Self {
+        LefDefOptions {
+            divider_char: "/".to_string(),
+            bus_bit_chars: "[]".to_string(),
+            units_microns: 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefOrientation {
+    N,
+    S,
+    E,
+    W,
+    FN,
+    FS,
+    FE,
+    FW,
+}
+
+impl DefOrientation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DefOrientation::N => "N",
+            DefOrientation::S => "S",
+            DefOrientation::E => "E",
+            DefOrientation::W => "W",
+            DefOrientation::FN => "FN",
+            DefOrientation::FS => "FS",
+            DefOrientation::FE => "FE",
+            DefOrientation::FW => "FW",
+        }
+    }
+
+    pub fn from_orientation(o: Orientation) -> DefOrientation {
+        match o {
+            Orientation::R0 => DefOrientation::N,
+            Orientation::R180 => DefOrientation::S,
+            Orientation::R90 => DefOrientation::W,
+            Orientation::R270 => DefOrientation::E,
+            Orientation::MY => DefOrientation::FN,
+            Orientation::MX => DefOrientation::FS,
+            Orientation::MX90 => DefOrientation::FW,
+            Orientation::MY90 => DefOrientation::FE,
+        }
+    }
+}
+
+/// Minimal description of a LEF macro for generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LefComponent {
+    pub name: String,
+    pub width: i64,
+    pub height: i64,
+    pub polygon: Vec<(i64, i64)>,
+}
+
+/// Minimal description of a DEF component placement for generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefComponent {
+    pub inst_name: String,
+    pub macro_name: String,
+    pub x: i64,
+    pub y: i64,
+    pub orientation: DefOrientation,
+}
+
+/// Generate a minimal LEF string from a list of macros.
+pub fn generate_lef(macros: &[LefComponent], opts: &LefDefOptions) -> String {
+    let mut s = String::new();
+    s.push_str("VERSION 5.8 ;\n");
+    s.push_str(&format!("DIVIDERCHAR \"{}\" ;\n", opts.divider_char));
+    s.push_str(&format!("BUSBITCHARS \"{}\" ;\n", opts.bus_bit_chars));
+    s.push_str(&format!(
+        "UNITS\n  DATABASE MICRONS {} ;\nEND UNITS\n\n",
+        opts.units_microns
+    ));
+    for m in macros {
+        // Basic macro with SIZE as bbox and an OBS POLYGON to capture shape
+        s.push_str(&format!("MACRO {}\n", m.name));
+        s.push_str("  CLASS BLOCK ;\n");
+        s.push_str("  ORIGIN 0 0 ;\n");
+        s.push_str(&format!("  SIZE {} BY {} ;\n", m.width, m.height));
+        let poly = polygon_string(&m.polygon);
+        s.push_str("  OBS\n");
+        s.push_str("    LAYER OUTLINE ;\n");
+        s.push_str(&format!("      {}\n", poly));
+        s.push_str("  END OBS\n");
+        s.push_str("END ");
+        s.push_str(&m.name);
+        s.push_str("\n\n");
+    }
+    s
+}
+
+/// Generate a minimal DEF string with placed components.
+pub fn generate_def(
+    design_name: &str,
+    components: &[DefComponent],
+    opts: &LefDefOptions,
+) -> String {
+    let mut s = String::new();
+    s.push_str("VERSION 5.8 ;\n");
+    s.push_str(&format!("DIVIDERCHAR \"{}\" ;\n", opts.divider_char));
+    s.push_str(&format!("BUSBITCHARS \"{}\" ;\n", opts.bus_bit_chars));
+    s.push_str(&format!("DESIGN {} ;\n", design_name));
+    s.push_str(&format!(
+        "UNITS DISTANCE MICRONS {} ;\n\n",
+        opts.units_microns
+    ));
+
+    s.push_str(&format!("COMPONENTS {} ;\n", components.len()));
+    for c in components {
+        s.push_str(&format!(
+            "  - {} {} + PLACED ( {} {} ) {} ;\n",
+            c.inst_name,
+            c.macro_name,
+            c.x,
+            c.y,
+            c.orientation.as_str()
+        ));
+    }
+    s.push_str("END COMPONENTS\n\n");
+    s.push_str("END DESIGN\n");
+    s
+}
+
+/// Write LEF text to a file.
+pub fn write_lef_file<P: AsRef<Path>>(
+    path: P,
+    macros: &[LefComponent],
+    opts: &LefDefOptions,
+) -> std::io::Result<()> {
+    let text = generate_lef(macros, opts);
+    fs::write(path, text)
+}
+
+/// Write DEF text to a file.
+pub fn write_def_file<P: AsRef<Path>>(
+    path: P,
+    design_name: &str,
+    components: &[DefComponent],
+    opts: &LefDefOptions,
+) -> std::io::Result<()> {
+    let text = generate_def(design_name, components, opts);
+    fs::write(path, text)
+}
+
+fn polygon_string(polygon: &[(i64, i64)]) -> String {
+    let mut s = String::from("POLYGON ( ");
+    for (i, p) in polygon.iter().enumerate() {
+        if i > 0 {
+            s.push(' ');
+        }
+        s.push_str(&format!("{} {}", p.0, p.1));
+    }
+    s.push_str(" ) ;");
+    s
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ mod mod_def;
 use mod_def::ModDefCore;
 pub use mod_def::ParameterType;
 pub use mod_def::{ConvertibleToModDef, ModDef};
+pub use mod_def::{Coordinate, Orientation, Placement, RectilinearShape};
+pub mod lefdef;
+pub use lefdef::LefDefOptions;
 
 mod usage;
 pub use usage::Usage;

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -12,13 +12,17 @@ pub use core::ModDefCore;
 
 mod dtypes;
 pub(crate) use dtypes::{Assignment, InstConnection, PortSliceOrWire, Wire};
+pub use dtypes::{Coordinate, Orientation, Placement, RectilinearShape};
 
 mod emit;
 mod feedthrough;
 mod instances;
 mod intf;
 mod parameterize;
+mod placement;
 pub use parameterize::ParameterType;
+pub use placement::CalculatedPlacement;
+mod lefdef;
 mod parser;
 mod parser_cfg;
 pub use parser_cfg::ParserConfig;
@@ -58,6 +62,8 @@ impl ModDef {
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
+                shape: None,
+                inst_placements: IndexMap::new(),
             })),
         }
     }
@@ -82,6 +88,18 @@ impl ModDef {
             );
         }
         self.core.borrow_mut().usage = usage;
+    }
+
+    /// Define a rectangular shape at (0, 0) with width and height. This is
+    /// shorthand for set_shape with four rectilinear points.
+    pub fn set_width_height(&self, width: i64, height: i64) {
+        assert!(width > 0 && height > 0, "Width and height must be positive");
+        self.set_shape(RectilinearShape::from_width_height(width, height));
+    }
+
+    /// Define a rectilinear polygonal shape by its vertices in order.
+    pub fn set_shape(&self, shape: RectilinearShape) {
+        self.core.borrow_mut().shape = Some(shape);
     }
 }
 

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -35,4 +35,6 @@ pub struct ModDefCore {
     pub(crate) enum_ports: IndexMap<String, String>,
     pub(crate) adjacency_matrix: HashMap<String, HashSet<String>>,
     pub(crate) ignore_adjacency: HashSet<String>,
+    pub(crate) shape: Option<crate::mod_def::dtypes::RectilinearShape>,
+    pub(crate) inst_placements: IndexMap<String, crate::mod_def::dtypes::Placement>,
 }

--- a/src/mod_def/dtypes.rs
+++ b/src/mod_def/dtypes.rs
@@ -35,3 +35,226 @@ pub(crate) enum PortSliceOrWire {
     PortSlice(PortSlice),
     Wire(Wire),
 }
+
+// Floorplanning-related types
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Coordinate {
+    pub x: i64,
+    pub y: i64,
+}
+
+impl From<(i64, i64)> for Coordinate {
+    fn from(value: (i64, i64)) -> Self {
+        Coordinate {
+            x: value.0,
+            y: value.1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Orientation {
+    R0,
+    R90,
+    R180,
+    R270,
+    MX,
+    MY,
+    MX90,
+    MY90,
+}
+
+#[derive(Debug, Clone)]
+pub struct RectilinearShape(pub Vec<Coordinate>);
+
+pub struct BoundingBox {
+    pub min_x: i64,
+    pub max_x: i64,
+    pub min_y: i64,
+    pub max_y: i64,
+}
+
+impl RectilinearShape {
+    pub fn new(points: Vec<Coordinate>) -> Self {
+        assert!(
+            is_rectilinear(&points),
+            "Only rectilinear polygons are supported"
+        );
+        RectilinearShape(points)
+    }
+
+    pub fn from_width_height(width: i64, height: i64) -> Self {
+        Self::new(vec![
+            Coordinate { x: 0, y: 0 },
+            Coordinate { x: width, y: 0 },
+            Coordinate {
+                x: width,
+                y: height,
+            },
+            Coordinate { x: 0, y: height },
+        ])
+    }
+
+    pub fn apply_transform(&self, m: &Mat3) -> RectilinearShape {
+        let pts = self
+            .0
+            .iter()
+            .map(|p| {
+                let v = nalgebra::Vector3::new(p.x, p.y, 1);
+                let result = m.0 * v;
+                Coordinate {
+                    x: result[0],
+                    y: result[1],
+                }
+            })
+            .collect();
+        RectilinearShape(pts)
+    }
+
+    pub fn bbox(&self) -> BoundingBox {
+        let mut min_x = i64::MAX;
+        let mut max_x = i64::MIN;
+        let mut min_y = i64::MAX;
+        let mut max_y = i64::MIN;
+        for p in &self.0 {
+            if p.x < min_x {
+                min_x = p.x;
+            }
+            if p.x > max_x {
+                max_x = p.x;
+            }
+            if p.y < min_y {
+                min_y = p.y;
+            }
+            if p.y > max_y {
+                max_y = p.y;
+            }
+        }
+        BoundingBox {
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+        }
+    }
+}
+
+impl PartialEq for RectilinearShape {
+    fn eq(&self, other: &Self) -> bool {
+        let a = &self.0;
+        let b = &other.0;
+        if a.len() != b.len() {
+            return false;
+        }
+        if a.is_empty() {
+            return true;
+        }
+        // rotation-invariant equality: try aligning every index
+        for start in 0..b.len() {
+            let mut all_match = true;
+            for (i, a_i) in a.iter().enumerate() {
+                let j = (start + i) % b.len();
+                if a_i != &b[j] {
+                    all_match = false;
+                    break;
+                }
+            }
+            if all_match {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl Eq for RectilinearShape {}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Placement {
+    pub coordinate: Coordinate,
+    pub orientation: Orientation,
+}
+
+impl Default for Placement {
+    fn default() -> Self {
+        Placement {
+            coordinate: Coordinate { x: 0, y: 0 },
+            orientation: Orientation::R0,
+        }
+    }
+}
+
+pub(crate) fn is_rectilinear(points: &[Coordinate]) -> bool {
+    // Check that all edges are axis-aligned
+    for i in 0..points.len() {
+        let a = points[i];
+        // Modulo is needed to check the last edge
+        let b = points[(i + 1) % points.len()];
+        if !(a.x == b.x || a.y == b.y) {
+            return false;
+        }
+        if a.x == b.x && a.y == b.y {
+            // degenerate edge
+            return false;
+        }
+    }
+    true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Mat3(pub nalgebra::Matrix3<i64>);
+
+impl Mat3 {
+    pub fn identity() -> Mat3 {
+        Mat3(nalgebra::Matrix3::identity())
+    }
+
+    pub fn translate(dx: i64, dy: i64) -> Mat3 {
+        Mat3(nalgebra::Matrix3::new(1, 0, dx, 0, 1, dy, 0, 0, 1))
+    }
+
+    pub fn from_orientation(o: Orientation) -> Mat3 {
+        const ROTATE_90: Mat3 = Mat3(nalgebra::Matrix3::new(0, -1, 0, 1, 0, 0, 0, 0, 1));
+        const MIRROR_X: Mat3 = Mat3(nalgebra::Matrix3::new(1, 0, 0, 0, -1, 0, 0, 0, 1));
+        const MIRROR_Y: Mat3 = Mat3(nalgebra::Matrix3::new(-1, 0, 0, 0, 1, 0, 0, 0, 1));
+
+        match o {
+            Orientation::R0 => Self::identity(),
+            Orientation::R90 => ROTATE_90,
+            Orientation::R180 => &ROTATE_90 * &ROTATE_90,
+            Orientation::R270 => &(&ROTATE_90 * &ROTATE_90) * &ROTATE_90,
+            Orientation::MX => MIRROR_X,
+            Orientation::MY => MIRROR_Y,
+            Orientation::MX90 => &ROTATE_90 * &MIRROR_X,
+            Orientation::MY90 => &ROTATE_90 * &MIRROR_Y,
+        }
+    }
+
+    pub fn as_orientation(&self) -> Orientation {
+        for orientation in [
+            Orientation::R0,
+            Orientation::R90,
+            Orientation::R180,
+            Orientation::R270,
+            Orientation::MX,
+            Orientation::MY,
+            Orientation::MX90,
+            Orientation::MY90,
+        ] {
+            let ref_mat = Self::from_orientation(orientation);
+            if self.0.fixed_view::<2, 2>(0, 0) == ref_mat.0.fixed_view::<2, 2>(0, 0) {
+                return orientation;
+            }
+        }
+        panic!("Unsupported orientation: {:?}", self);
+    }
+}
+
+impl std::ops::Mul<&Mat3> for &Mat3 {
+    type Output = Mat3;
+    fn mul(self, rhs: &Mat3) -> Mat3 {
+        Mat3(self.0 * rhs.0)
+    }
+}

--- a/src/mod_def/lefdef.rs
+++ b/src/mod_def/lefdef.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::Path;
+
+use indexmap::IndexMap;
+
+use crate::lefdef::{self, DefComponent, LefComponent};
+use crate::mod_def::CalculatedPlacement;
+use crate::{LefDefOptions, ModDef, RectilinearShape};
+
+impl ModDef {
+    /// Emit LEF and DEF strings for this module using collected shapes and
+    /// placements. Returns (lef_string, def_string).
+    pub fn emit_lef_def(&self, opts: &LefDefOptions) -> (String, String) {
+        let (placements, shapes) = self.collect_placements_and_shapes();
+        let lef_components: IndexMap<String, LefComponent> = shapes
+            .iter()
+            .map(|(name, shape)| {
+                let bbox = shape.bbox();
+                assert!(bbox.min_x >= 0, "LEFs do not support negative coordinates");
+                assert!(bbox.min_y >= 0, "LEFs do not support negative coordinates");
+                (
+                    name.clone(),
+                    LefComponent {
+                        name: name.clone(),
+                        width: bbox.max_x,
+                        height: bbox.max_y,
+                        polygon: shape.0.iter().map(|p| (p.x, p.y)).collect(),
+                    },
+                )
+            })
+            .collect();
+
+        let def_components = placements_to_def_components(&placements, &lef_components);
+
+        let design_name = self.get_name();
+        let lef_components_vec: Vec<LefComponent> = lef_components.values().cloned().collect();
+        let def_components_vec: Vec<DefComponent> = def_components.values().cloned().collect();
+        let lef = lefdef::generate_lef(&lef_components_vec, opts);
+        let def = lefdef::generate_def(&design_name, &def_components_vec, opts);
+        (lef, def)
+    }
+
+    /// Emit LEF and DEF to files.
+    pub fn emit_lef_def_to_files<P1: AsRef<Path>, P2: AsRef<Path>>(
+        &self,
+        lef_path: P1,
+        def_path: P2,
+        opts: &LefDefOptions,
+    ) -> std::io::Result<()> {
+        let (lef, def) = self.emit_lef_def(opts);
+        fs::write(lef_path, lef)?;
+        fs::write(def_path, def)?;
+        Ok(())
+    }
+}
+
+fn placements_to_def_components(
+    placements: &IndexMap<String, CalculatedPlacement>,
+    lef_components: &IndexMap<String, LefComponent>,
+) -> IndexMap<String, DefComponent> {
+    placements
+        .iter()
+        .map(|(inst_name, p)| {
+            let lef_component = lef_components.get(&p.module).unwrap_or_else(|| {
+                panic!(
+                    "No LEF component found for module '{}' (needed for DEF placement)",
+                    p.module
+                )
+            });
+            let bbox =
+                RectilinearShape::from_width_height(lef_component.width, lef_component.height)
+                    .apply_transform(&p.transform)
+                    .bbox();
+            (
+                inst_name.clone(),
+                DefComponent {
+                    inst_name: inst_name.clone(),
+                    macro_name: p.module.clone(),
+                    // Note that DEF placement is for the lower-left corner of the shape
+                    x: bbox.min_x,
+                    y: bbox.min_y,
+                    orientation: lefdef::DefOrientation::from_orientation(
+                        p.transform.as_orientation(),
+                    ),
+                },
+            )
+        })
+        .collect()
+}

--- a/src/mod_def/parameterize.rs
+++ b/src/mod_def/parameterize.rs
@@ -70,7 +70,7 @@ impl ModDef {
         let original_name = &self.core.borrow().name;
         let mut def_name_default = original_name.clone();
         for (param_name, param_value) in &bigint_params {
-            def_name_default.push_str(&format!("_{}_{}", param_name, param_value.to_string()));
+            def_name_default.push_str(&format!("_{}_{}", param_name, param_value));
         }
         let def_name = def_name.unwrap_or(&def_name_default);
 
@@ -295,6 +295,8 @@ impl ModDef {
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
+                shape: None,
+                inst_placements: IndexMap::new(),
             })),
         }
     }

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -125,6 +125,8 @@ impl ModDef {
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
+                shape: None,
+                inst_placements: IndexMap::new(),
             })),
         }
     }

--- a/src/mod_def/parser_cfg.rs
+++ b/src/mod_def/parser_cfg.rs
@@ -42,7 +42,7 @@ impl Default for ParserConfig<'_> {
 }
 
 impl ParserConfig<'_> {
-    pub fn to_slang_config(&self) -> SlangConfig {
+    pub fn to_slang_config(&self) -> SlangConfig<'_> {
         SlangConfig {
             sources: self.sources,
             tops: self.tops,

--- a/src/mod_def/placement.rs
+++ b/src/mod_def/placement.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use indexmap::IndexMap;
+
+use crate::mod_def::dtypes::Mat3;
+use crate::mod_def::dtypes::RectilinearShape;
+use crate::{ModDef, Usage};
+
+impl ModDef {
+    /// Collect placements and shapes for modules where usage stops descent
+    /// (EmitStubAndStop or EmitNothingAndStop).
+    pub fn collect_placements_and_shapes(
+        &self,
+    ) -> (
+        IndexMap<String, CalculatedPlacement>,
+        IndexMap<String, RectilinearShape>,
+    ) {
+        let mut placements = IndexMap::new();
+        let mut shapes = IndexMap::new();
+        self.collect_placements_and_shapes_helper(
+            &mut placements,
+            &mut shapes,
+            &self.get_name(),
+            Mat3::identity(),
+        );
+        (placements, shapes)
+    }
+
+    fn collect_placements_and_shapes_helper(
+        &self,
+        placements: &mut IndexMap<String, CalculatedPlacement>,
+        shapes: &mut IndexMap<String, RectilinearShape>,
+        prefix: &str,
+        m_curr: Mat3,
+    ) {
+        for child in self.get_instances() {
+            let child_mod_def = child.get_mod_def();
+            let child_mod_def_name = child_mod_def.get_name();
+            let child_mod_inst_name = child.name();
+            let child_path = format!("{prefix}/{child_mod_inst_name}");
+
+            // Instance-local placement matrix: Translation * Orientation
+            let child_m = if let Some(placement) =
+                self.core.borrow().inst_placements.get(child_mod_inst_name)
+            {
+                // Determine the orientation and translation transformations
+                let orientation_transform = Mat3::from_orientation(placement.orientation);
+                let translation_transform =
+                    Mat3::translate(placement.coordinate.x, placement.coordinate.y);
+
+                // Determine the local transformation
+                let m_local = &translation_transform * &orientation_transform;
+
+                // Apply the transformations that occur above this hierarchical level
+                &m_curr * &m_local
+            } else {
+                m_curr
+            };
+
+            match child.get_mod_def().core.borrow().usage {
+                Usage::EmitStubAndStop | Usage::EmitDefinitionAndStop => {
+                    // Add placement information for this instance
+                    placements.insert(
+                        child_path.clone(),
+                        CalculatedPlacement {
+                            module: child_mod_def_name.clone(),
+                            transform: child_m,
+                        },
+                    );
+                    // Add shape information for this instance if not already present
+                    shapes
+                        .entry(child_mod_def_name.to_string())
+                        .or_insert_with(|| {
+                            if let Some(shape) = &child.get_mod_def().core.borrow().shape {
+                                shape.clone()
+                            } else {
+                                panic!(
+                                "Module '{}' marked to stop (usage={:?}) but has no shape defined",
+                                child_mod_def_name, child.get_mod_def().core.borrow().usage
+                            );
+                            }
+                        });
+                }
+                Usage::EmitNothingAndStop => (),
+                Usage::EmitDefinitionAndDescend => {
+                    child_mod_def.collect_placements_and_shapes_helper(
+                        placements,
+                        shapes,
+                        &child_path,
+                        child_m,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Public placement info for block instances.
+pub struct CalculatedPlacement {
+    pub module: String,
+    pub transform: Mat3,
+}

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -38,6 +38,8 @@ impl ModDef {
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
+                shape: self.core.borrow().shape.clone(),
+                inst_placements: IndexMap::new(),
             })),
         }
     }

--- a/src/mod_inst.rs
+++ b/src/mod_inst.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::rc::Weak;
 
 use crate::{ConvertibleToModDef, Intf, ModDef, ModDefCore, Port, PortSlice};
+use crate::{Coordinate, Orientation, Placement};
 
 /// Represents an instance of a module definition, like `<mod_def_name>
 /// <mod_inst_name> ( ... );` in Verilog.
@@ -144,6 +145,18 @@ impl ModInst {
             .borrow_mut()
             .ignore_adjacency
             .insert(self.name.clone());
+    }
+
+    /// Place this instance at a coordinate with an orientation.
+    pub fn place<C: Into<Coordinate>>(&self, coordinate: C, orientation: Orientation) {
+        let core = self.mod_def_core.upgrade().unwrap();
+        core.borrow_mut().inst_placements.insert(
+            self.name.clone(),
+            Placement {
+                coordinate: coordinate.into(),
+                orientation,
+            },
+        );
     }
 }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -2,7 +2,7 @@
 
 /// Represents how a module definition should be used when validating and/or
 /// emitting Verilog.
-#[derive(PartialEq, Default, Clone)]
+#[derive(PartialEq, Default, Clone, Debug)]
 pub enum Usage {
     /// When validating, validate the module definition and descend into its
     /// instances. When emitting Verilog, emit its definition and descend into

--- a/tests/lefdef_gen.rs
+++ b/tests/lefdef_gen.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use topstitch::lefdef::{generate_def, generate_lef, DefComponent, DefOrientation, LefComponent};
+use topstitch::LefDefOptions;
+
+#[test]
+fn generate_lef_basic() {
+    let macros = vec![LefComponent {
+        name: "BLOCK_A".to_string(),
+        width: 100,
+        height: 200,
+        polygon: vec![(0, 0), (100, 0), (100, 200), (0, 200)],
+    }];
+    let lef = generate_lef(&macros, &LefDefOptions::default());
+    assert!(lef.contains("MACRO BLOCK_A"));
+    assert!(lef.contains("SIZE 100 BY 200 ;"));
+    assert!(lef.contains("POLYGON ( 0 0 100 0 100 200 0 200 ) ;"));
+}
+
+#[test]
+fn generate_def_components() {
+    let comps = vec![
+        DefComponent {
+            inst_name: "top/inst0".to_string(),
+            macro_name: "BLOCK_A".to_string(),
+            x: 10,
+            y: 20,
+            orientation: DefOrientation::N,
+        },
+        DefComponent {
+            inst_name: "top/inst1".to_string(),
+            macro_name: "BLOCK_B".to_string(),
+            x: -5,
+            y: 7,
+            orientation: DefOrientation::E,
+        },
+    ];
+    let def = generate_def("top", &comps, &LefDefOptions::default());
+    assert!(def.contains("DESIGN top ;"));
+    assert!(def.contains("- top/inst0 BLOCK_A + PLACED ( 10 20 ) N ;"));
+    assert!(def.contains("- top/inst1 BLOCK_B + PLACED ( -5 7 ) E ;"));
+}

--- a/tests/placement.rs
+++ b/tests/placement.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use topstitch::{ModDef, Orientation, RectilinearShape, Usage};
+
+#[test]
+fn placement_basic() {
+    let top = ModDef::new("top");
+
+    let block = ModDef::new("block");
+    block.set_usage(Usage::EmitStubAndStop);
+    block.set_width_height(100, 200);
+
+    // Instantiate and place block in top
+    let b_inst = top.instantiate(&block, Some("b_inst_0"), None);
+    b_inst.place((10, 20), Orientation::R0);
+
+    // Compute placements and verify absolute shape
+    let (placements, shapes) = top.collect_placements_and_shapes();
+    let b_placed = placements
+        .get("top/b_inst_0")
+        .expect("instance top/b_inst_0 not found");
+    let b_shape = shapes.get(&b_placed.module).expect("def block missing");
+    let abs_shape = b_shape.apply_transform(&b_placed.transform);
+    assert_eq!(
+        abs_shape,
+        RectilinearShape::new(vec![
+            (10, 20).into(),
+            (110, 20).into(),
+            (110, 220).into(),
+            (10, 220).into(),
+        ])
+    );
+}
+
+#[test]
+fn placement_skip_level() {
+    let top = ModDef::new("top");
+    let intermediate = ModDef::new("intermediate");
+    let block = ModDef::new("block");
+
+    block.set_usage(Usage::EmitStubAndStop);
+    block.set_width_height(100, 200);
+
+    // Instantiate and place block in intermediate hierarchy level
+    top.instantiate(&intermediate, Some("i_inst_0"), None);
+    let b_inst = intermediate.instantiate(&block, Some("b_inst_0"), None);
+    b_inst.place((10, 20), Orientation::R0);
+
+    // Compute placements and verify absolute shape
+    let (placements, shapes) = top.collect_placements_and_shapes();
+    let b_placed = placements
+        .get("top/i_inst_0/b_inst_0")
+        .expect("instance top/i_inst_0/b_inst_0 not found");
+    let b_shape = shapes.get(&b_placed.module).expect("def block missing");
+    let abs_shape = b_shape.apply_transform(&b_placed.transform);
+    assert_eq!(
+        abs_shape,
+        RectilinearShape::new(vec![
+            (10, 20).into(),
+            (110, 20).into(),
+            (110, 220).into(),
+            (10, 220).into(),
+        ])
+    );
+}
+
+#[test]
+fn placement_relative_basic() {
+    let top = ModDef::new("top");
+    let intermediate = ModDef::new("intermediate");
+    let block = ModDef::new("block");
+
+    block.set_usage(Usage::EmitStubAndStop);
+    block.set_width_height(100, 200);
+
+    // Instantiate and place block in intermediate
+    let b_inst = intermediate.instantiate(&block, Some("b_inst_0"), None);
+    b_inst.place((12, 34), Orientation::R270);
+
+    let i_inst = top.instantiate(&intermediate, Some("i_inst_0"), None);
+    i_inst.place((56, 78), Orientation::MY);
+
+    // Compute placements and verify absolute shape
+    let (placements, shapes) = top.collect_placements_and_shapes();
+    let b_placed = placements
+        .get("top/i_inst_0/b_inst_0")
+        .expect("instance top/i_inst_0/b_inst_0 not found");
+    let b_shape = shapes.get(&b_placed.module).expect("def block missing");
+    let abs_shape = b_shape.apply_transform(&b_placed.transform);
+    assert_eq!(
+        abs_shape,
+        RectilinearShape::new(vec![
+            (44, 112).into(),
+            (44, 12).into(),
+            (-156, 12).into(),
+            (-156, 112).into(),
+        ])
+    );
+}
+
+#[test]
+fn placement_relative_to_parent() {
+    let top = ModDef::new("top");
+    let intermediate = ModDef::new("intermediate");
+    let block = ModDef::new("block");
+
+    block.set_usage(Usage::EmitStubAndStop);
+    block.set_width_height(400, 300);
+
+    let b_inst = intermediate.instantiate(&block, Some("b_inst_0"), None);
+    b_inst.place((100, 200), Orientation::R0);
+
+    for (index, orientation) in [
+        Orientation::R0,
+        Orientation::MX,
+        Orientation::R180,
+        Orientation::MY,
+    ]
+    .iter()
+    .enumerate()
+    {
+        let i_inst = top.instantiate(&intermediate, Some(&format!("i_inst_{}", index)), None);
+        i_inst.place((0, 0), *orientation);
+    }
+
+    // Compute placements and verify absolute shape
+    let (placements, shapes) = top.collect_placements_and_shapes();
+
+    let b_placed: std::collections::HashMap<_, _> = placements
+        .iter()
+        .map(|(inst_name, p)| {
+            let b_shape = shapes.get(&p.module).expect("def block missing");
+            let abs_shape = b_shape.apply_transform(&p.transform);
+            (inst_name.clone(), abs_shape)
+        })
+        .collect();
+
+    assert_eq!(
+        b_placed.get("top/i_inst_0/b_inst_0"),
+        Some(&RectilinearShape::new(vec![
+            (100, 200).into(),
+            (500, 200).into(),
+            (500, 500).into(),
+            (100, 500).into(),
+        ]))
+    );
+
+    assert_eq!(
+        b_placed.get("top/i_inst_1/b_inst_0"),
+        Some(&RectilinearShape::new(vec![
+            (100, -200).into(),
+            (500, -200).into(),
+            (500, -500).into(),
+            (100, -500).into(),
+        ]))
+    );
+
+    assert_eq!(
+        b_placed.get("top/i_inst_2/b_inst_0"),
+        Some(&RectilinearShape::new(vec![
+            (-100, -200).into(),
+            (-500, -200).into(),
+            (-500, -500).into(),
+            (-100, -500).into(),
+        ]))
+    );
+
+    assert_eq!(
+        b_placed.get("top/i_inst_3/b_inst_0"),
+        Some(&RectilinearShape::new(vec![
+            (-100, 200).into(),
+            (-500, 200).into(),
+            (-500, 500).into(),
+            (-100, 500).into(),
+        ]))
+    );
+}


### PR DESCRIPTION
**Overview**
- **APIs:** Adds `ModDef::emit_lef_def(opts)` to return LEF/DEF strings and `ModDef::emit_lef_def_to_files(lef_path, def_path, opts)` to write them to disk.
- **Traversal:** Uses `Usage` to control descent. Modules marked `EmitStubAndStop` or `EmitDefinitionAndStop` act as leaves for physical design; they produce a LEF macro (from their shape) and DEF component placements (from instance placements). This is an extension of the current meaning of `Usage`, which indicates leaves for logical design. In the future, DEF might be used to represent leaves, but for now this is a convenient way to create empty boxes and view placements with KLayout.

**Shaping and Placement**
- **`ModDef`:** `set_width_height(w, h)` and `set_shape(RectilinearShape)` define leaf geometry. `EmitStubAndStop` and `EmitDefinitionAndStop` modules must define a shape.
- **`ModInst`:** `place((x, y), Orientation)` positions instances. Supported orientations: `R0`, `R90`, `R180`, `R270`, `MX`, `MY`, `MX90`, `MY90`. These are internally converted to the corresponding DEF orientations. Note that placements can be composed hierarchically; this is automatically tracked by TopStitch.

**Implementation Notes**
- **Geometry:** Introduces `RectilinearShape`, `Mat3`, `Orientation`, and `CalculatedPlacement`; leverages `nalgebra` for transforms.
- **Tests:** Cover LEF/DEF emission, hierarchical placement composition, and orientation handling.