### PR TITLE
Low-level pinning features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/examples/pinning.rs
+++ b/examples/pinning.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use topstitch::{BoundingBox, LefDefOptions, Mat3, ModDef, Orientation, Polygon, Usage, IO};
+
+const A_WIDTH: i64 = 100;
+const A_NUM_PINS: usize = 4;
+const B_NUM_PINS: usize = 8;
+const C_NUM_PINS: usize = 2;
+const TOTAL_PINS: usize = B_NUM_PINS;
+const B_WIDTH: i64 = 300;
+const C_WIDTH: i64 = 200;
+const PIN_LAYER: &str = "M1";
+const PIN_WIDTH: i64 = 10;
+const PIN_DEPTH: i64 = 20;
+
+// Build a simple leaf module with pins on the left and right edges.
+fn build_leaf(name: &str, width: i64, num_pins: usize) -> ModDef {
+    // Define the module
+    let m = ModDef::new(name);
+    m.set_shape(Polygon::from_width_height(
+        width,
+        2 * (num_pins as i64) * PIN_WIDTH,
+    ));
+    m.set_layer(format!("OUTLINE_{}", name.to_uppercase()));
+
+    // Input and output ports
+    m.add_port("in", IO::Input(num_pins));
+    m.add_port("out", IO::Output(num_pins));
+
+    // Define pin shape
+    let pin_shape = Polygon::from_bbox(&BoundingBox {
+        min_x: 0,
+        min_y: -PIN_WIDTH / 2,
+        max_x: PIN_DEPTH,
+        max_y: PIN_WIDTH / 2,
+    });
+
+    // Define input pins on left edge (layer M1)
+    let flipped = pin_shape.apply_transform(&Mat3::from_orientation(Orientation::MY));
+    for i in 0..num_pins {
+        let y = PIN_WIDTH + (i as i64) * (2 * PIN_WIDTH);
+        m.get_port("in")
+            .bit(i)
+            .define_physical_pin(PIN_LAYER, (0, y).into(), pin_shape.clone());
+        m.get_port("out")
+            .bit(i)
+            .define_physical_pin(PIN_LAYER, (width, y).into(), flipped.clone());
+    }
+
+    // Mark as a leaf for LEF/DEF emission
+    m.set_usage(Usage::EmitStubAndStop);
+    m
+}
+
+fn main() {
+    // Paths for output files under examples/output
+    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let out_dir = examples.join("output");
+    std::fs::create_dir_all(&out_dir).expect("create examples/output/");
+
+    // Build A, B, and C modules
+    let a = build_leaf("A", A_WIDTH, A_NUM_PINS);
+    let b = build_leaf("B", B_WIDTH, B_NUM_PINS);
+    let c = build_leaf("C", C_WIDTH, C_NUM_PINS);
+
+    let a_height = a.bbox().unwrap().get_height();
+    let c_height = c.bbox().unwrap().get_height();
+
+    // Top-level that places instances of A, B, and C
+    let top = ModDef::new("Top");
+    let a_instances = top.instantiate_array(&a, &[TOTAL_PINS / A_NUM_PINS], None, None);
+    let b_instance = top.instantiate(&b, None, None);
+    let c_instances = top.instantiate_array(&c, &[TOTAL_PINS / C_NUM_PINS], None, None);
+
+    let b_inputs = b_instance.get_port("in").subdivide(a_instances.len());
+    for (i, a_inst) in a_instances.iter().enumerate() {
+        a_inst.place((0, (i as i64) * a_height), Orientation::R0);
+        a_inst.get_port("out").connect(&b_inputs[i]);
+    }
+
+    b_instance.place((A_WIDTH, 0), Orientation::R0);
+
+    let b_outputs = b_instance.get_port("out").subdivide(c_instances.len());
+    for (i, c_inst) in c_instances.iter().enumerate() {
+        c_inst.place((A_WIDTH + B_WIDTH, (i as i64) * c_height), Orientation::R0);
+        c_inst.get_port("in").connect(&b_outputs[i]);
+    }
+
+    // Emit LEF/DEF for viewing
+    let lef_path = out_dir.join("pinning.lef");
+    let def_path = out_dir.join("pinning.def");
+    top.emit_lef_def_to_files(&lef_path, &def_path, &LefDefOptions::default())
+        .expect("emit LEF/DEF");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ pub use port_slice::{ConvertibleToPortSlice, PortSlice};
 mod mod_def;
 use mod_def::ModDefCore;
 pub use mod_def::ParameterType;
-pub use mod_def::{CalculatedPlacement, Coordinate, Orientation, Placement, RectilinearShape};
+pub use mod_def::{
+    BoundingBox, CalculatedPlacement, Coordinate, Mat3, Orientation, Placement, Polygon,
+};
 pub use mod_def::{ConvertibleToModDef, ModDef};
 pub mod lefdef;
 pub use lefdef::LefDefOptions;

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -7,10 +7,12 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 use num_bigint::BigInt;
 
-use crate::mod_def::dtypes::VerilogImport;
+use crate::mod_def::dtypes::{PhysicalPin, VerilogImport};
 
 pub(crate) use crate::mod_def::{Assignment, InstConnection, Wire};
 use crate::{PortSlice, Usage, IO};
+
+type PhysicalPinMap = IndexMap<String, Vec<Option<PhysicalPin>>>;
 
 /// Data structure representing a module definition.
 ///
@@ -35,6 +37,8 @@ pub struct ModDefCore {
     pub(crate) enum_ports: IndexMap<String, String>,
     pub(crate) adjacency_matrix: HashMap<String, HashSet<String>>,
     pub(crate) ignore_adjacency: HashSet<String>,
-    pub(crate) shape: Option<crate::mod_def::dtypes::RectilinearShape>,
+    pub(crate) shape: Option<crate::mod_def::dtypes::Polygon>,
+    pub(crate) layer: Option<String>,
     pub(crate) inst_placements: IndexMap<String, crate::mod_def::dtypes::Placement>,
+    pub(crate) physical_pins: PhysicalPinMap,
 }

--- a/src/mod_def/lefdef.rs
+++ b/src/mod_def/lefdef.rs
@@ -7,30 +7,81 @@ use indexmap::IndexMap;
 
 use crate::lefdef::{self, DefComponent, LefComponent};
 use crate::mod_def::CalculatedPlacement;
-use crate::{LefDefOptions, ModDef, RectilinearShape};
+use crate::{LefDefOptions, ModDef, Polygon};
 
 impl ModDef {
     /// Emit LEF and DEF strings for this module using collected shapes and
     /// placements. Returns (lef_string, def_string).
     pub fn emit_lef_def(&self, opts: &LefDefOptions) -> (String, String) {
-        let (placements, shapes) = self.collect_placements_and_shapes();
-        let lef_components: IndexMap<String, LefComponent> = shapes
-            .iter()
-            .map(|(name, shape)| {
-                let bbox = shape.bbox();
-                assert!(bbox.min_x >= 0, "LEFs do not support negative coordinates");
-                assert!(bbox.min_y >= 0, "LEFs do not support negative coordinates");
-                (
-                    name.clone(),
-                    LefComponent {
-                        name: name.clone(),
-                        width: bbox.max_x,
-                        height: bbox.max_y,
+        let (placements, mod_defs) = self.collect_placements_and_mod_defs();
+        // Build components directly from referenced ModDefs
+        let mut lef_components: IndexMap<String, LefComponent> = IndexMap::new();
+        for (name, md) in mod_defs.iter() {
+            let core = md.core.borrow();
+            let shape = core.shape.as_ref().unwrap_or_else(|| {
+                panic!("Module '{}' marked to stop but has no shape defined", name)
+            });
+            let bbox = shape.bbox();
+            assert!(bbox.min_x >= 0, "LEFs do not support negative coordinates");
+            assert!(bbox.min_y >= 0, "LEFs do not support negative coordinates");
+
+            // Construct LEF pins from physical_pins in a deterministic order
+            let mut lef_pins = Vec::new();
+            for (port_name, pins) in core.physical_pins.iter() {
+                let port = core.ports.get(port_name).unwrap_or_else(|| {
+                    panic!(
+                        "Physical pin defined for unknown port {}.{}",
+                        core.name, port_name
+                    )
+                });
+                let direction = match port {
+                    crate::IO::Input(_) => "INPUT",
+                    crate::IO::Output(_) => "OUTPUT",
+                    crate::IO::InOut(_) => "INOUT",
+                }
+                .to_string();
+
+                for (bit, maybe_pin) in pins.iter().enumerate() {
+                    if let Some(pin) = maybe_pin {
+                        let name = format!("{}[{}]", &port_name, bit);
+                        let polygon_abs: Vec<(i64, i64)> = pin
+                            .polygon
+                            .0
+                            .iter()
+                            .map(|c| (c.x + pin.position.x, c.y + pin.position.y))
+                            .collect();
+                        lef_pins.push(crate::lefdef::LefPin {
+                            name,
+                            direction: direction.clone(),
+                            shape: crate::lefdef::LefShape {
+                                layer: pin.layer.clone(),
+                                polygon: polygon_abs,
+                            },
+                        });
+                    }
+                }
+            }
+
+            let layer_name = core
+                .layer
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| "OUTLINE".to_string());
+
+            lef_components.insert(
+                name.clone(),
+                LefComponent {
+                    name: name.clone(),
+                    width: bbox.max_x,
+                    height: bbox.max_y,
+                    shape: crate::lefdef::LefShape {
+                        layer: layer_name,
                         polygon: shape.0.iter().map(|p| (p.x, p.y)).collect(),
                     },
-                )
-            })
-            .collect();
+                    pins: lef_pins,
+                },
+            );
+        }
 
         let def_components = placements_to_def_components(&placements, &lef_components);
 
@@ -69,10 +120,9 @@ fn placements_to_def_components(
                     p.module
                 )
             });
-            let bbox =
-                RectilinearShape::from_width_height(lef_component.width, lef_component.height)
-                    .apply_transform(&p.transform)
-                    .bbox();
+            let bbox = Polygon::from_width_height(lef_component.width, lef_component.height)
+                .apply_transform(&p.transform)
+                .bbox();
             (
                 inst_name.clone(),
                 DefComponent {

--- a/src/mod_def/parameterize.rs
+++ b/src/mod_def/parameterize.rs
@@ -296,7 +296,9 @@ impl ModDef {
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
                 shape: None,
+                layer: None,
                 inst_placements: IndexMap::new(),
+                physical_pins: IndexMap::new(),
             })),
         }
     }

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -126,7 +126,9 @@ impl ModDef {
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
                 shape: None,
+                layer: None,
                 inst_placements: IndexMap::new(),
+                physical_pins: IndexMap::new(),
             })),
         }
     }

--- a/src/mod_def/pins.rs
+++ b/src/mod_def/pins.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use indexmap::map::Entry;
+
+use crate::mod_def::dtypes::{Coordinate, PhysicalPin, Polygon};
+use crate::PortSlice;
+
+impl PortSlice {
+    /// Define a physical pin for this single-bit PortSlice, with an arbitrary
+    /// polygon shape relative to `position` on the given `layer`.
+    pub fn define_physical_pin(
+        &self,
+        layer: impl AsRef<str>,
+        position: Coordinate,
+        polygon: Polygon,
+    ) {
+        self.check_validity();
+        assert!(
+            self.width() == 1,
+            "define_physical_pin must be called on a single bit slice"
+        );
+        // Only allowed on ModDef ports (not instance ports)
+        assert!(
+            matches!(self.port, crate::Port::ModDef { .. }),
+            "define_physical_pin must be called on a ModDef port"
+        );
+
+        let port_name = self.port.get_port_name();
+        let bit = self.lsb; // since width()==1
+
+        // Validate port exists and bit in range
+        let core_borrow = self.get_mod_def_core();
+        let mut core = core_borrow.borrow_mut();
+        let io = core.ports.get(&port_name).unwrap_or_else(|| {
+            panic!(
+                "Port {}.{} does not exist (adding physical pin)",
+                core.name, port_name
+            )
+        });
+        let width = io.width();
+        if bit >= width {
+            panic!(
+                "Bit {} out of range for port {}.{} with width {}",
+                bit, core.name, port_name, width
+            );
+        }
+
+        // Ensure vector of appropriate width exists on first use
+        let pins_for_port = match core.physical_pins.entry(port_name.to_string()) {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(v) => v.insert(vec![None; width]),
+        };
+
+        pins_for_port[bit] = Some(PhysicalPin {
+            layer: layer.as_ref().to_string(),
+            position,
+            polygon,
+        });
+    }
+}

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -39,7 +39,9 @@ impl ModDef {
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),
                 shape: self.core.borrow().shape.clone(),
+                layer: self.core.borrow().layer.clone(),
                 inst_placements: IndexMap::new(),
+                physical_pins: IndexMap::new(),
             })),
         }
     }

--- a/tests/lef_pins.rs
+++ b/tests/lef_pins.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use topstitch::{BoundingBox, LefDefOptions, Mat3, ModDef, Orientation, Polygon, IO};
+
+#[test]
+fn generate_lef_with_pins_and_positions() {
+    // Define a leaf block with shape and ports
+    let block = ModDef::new("block");
+    block.set_shape(Polygon::from_width_height(100, 50));
+    block.set_layer("OUTLINE");
+    block.add_port("a", IO::Input(2));
+    block.add_port("b", IO::Output(1));
+
+    // Define physical pins with explicit layer and position offsets
+    let pin = Polygon::from_bbox(&BoundingBox {
+        min_x: 0,
+        min_y: -5,
+        max_x: 20,
+        max_y: 5,
+    });
+    block
+        .get_port("a")
+        .bit(0)
+        .define_physical_pin("M1", (0, 15).into(), pin.clone());
+    block
+        .get_port("a")
+        .bit(1)
+        .define_physical_pin("M1", (0, 35).into(), pin.clone());
+    block.get_port("b").bit(0).define_physical_pin(
+        "M2",
+        (100, 25).into(),
+        pin.apply_transform(&Mat3::from_orientation(Orientation::MY)),
+    );
+
+    block.set_usage(topstitch::Usage::EmitStubAndStop);
+
+    // Create a top that instantiates and places the block
+    let top = ModDef::new("top");
+    let inst = top.instantiate(&block, Some("u0"), None);
+    inst.place((0, 0), Orientation::R0);
+
+    // Emit LEF and check contents
+    let (lef, _def) = top.emit_lef_def(&LefDefOptions::default());
+
+    // Macro and outline
+    assert!(lef.contains("MACRO block"));
+    assert!(lef.contains("LAYER OUTLINE"));
+    assert!(lef.contains("POLYGON ( 0 0 100 0 100 50 0 50 ) ;"));
+
+    // a[0]
+    assert!(lef.contains("PIN a[0]"));
+    assert!(lef.contains("DIRECTION INPUT"));
+    assert!(lef.contains("LAYER M1"));
+    assert!(lef.contains("POLYGON ( 0 10 20 10 20 20 0 20 ) ;"));
+
+    // a[1]
+    assert!(lef.contains("PIN a[1]"));
+    assert!(lef.contains("DIRECTION INPUT"));
+    assert!(lef.contains("LAYER M1"));
+    assert!(lef.contains("POLYGON ( 0 30 20 30 20 40 0 40 ) ;"));
+
+    // b[0]
+    assert!(lef.contains("PIN b[0]"));
+    assert!(lef.contains("DIRECTION OUTPUT"));
+    assert!(lef.contains("LAYER M2"));
+    assert!(lef.contains("POLYGON ( 100 20 80 20 80 30 100 30 ) ;"));
+}

--- a/tests/lefdef_gen.rs
+++ b/tests/lefdef_gen.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use topstitch::lefdef::{generate_def, generate_lef, DefComponent, DefOrientation, LefComponent};
+use topstitch::lefdef::{
+    generate_def, generate_lef, DefComponent, DefOrientation, LefComponent, LefShape,
+};
 use topstitch::LefDefOptions;
 
 #[test]
@@ -9,7 +11,11 @@ fn generate_lef_basic() {
         name: "BLOCK_A".to_string(),
         width: 100,
         height: 200,
-        polygon: vec![(0, 0), (100, 0), (100, 200), (0, 200)],
+        shape: LefShape {
+            layer: "OUTLINE".to_string(),
+            polygon: vec![(0, 0), (100, 0), (100, 200), (0, 200)],
+        },
+        pins: vec![],
     }];
     let lef = generate_lef(&macros, &LefDefOptions::default());
     assert!(lef.contains("MACRO BLOCK_A"));

--- a/tests/placement.rs
+++ b/tests/placement.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use topstitch::{ModDef, Orientation, RectilinearShape, Usage};
+use topstitch::{ModDef, Orientation, Polygon, Usage};
 
 #[test]
 fn placement_basic() {
@@ -15,15 +15,17 @@ fn placement_basic() {
     b_inst.place((10, 20), Orientation::R0);
 
     // Compute placements and verify absolute shape
-    let (placements, shapes) = top.collect_placements_and_shapes();
+    let (placements, _) = top.collect_placements_and_mod_defs();
     let b_placed = placements
         .get("top/b_inst_0")
         .expect("instance top/b_inst_0 not found");
-    let b_shape = shapes.get(&b_placed.module).expect("def block missing");
-    let abs_shape = b_shape.apply_transform(&b_placed.transform);
+    let abs_shape = block
+        .get_shape()
+        .unwrap()
+        .apply_transform(&b_placed.transform);
     assert_eq!(
         abs_shape,
-        RectilinearShape::new(vec![
+        Polygon::new(vec![
             (10, 20).into(),
             (110, 20).into(),
             (110, 220).into(),
@@ -47,15 +49,17 @@ fn placement_skip_level() {
     b_inst.place((10, 20), Orientation::R0);
 
     // Compute placements and verify absolute shape
-    let (placements, shapes) = top.collect_placements_and_shapes();
+    let (placements, _) = top.collect_placements_and_mod_defs();
     let b_placed = placements
         .get("top/i_inst_0/b_inst_0")
         .expect("instance top/i_inst_0/b_inst_0 not found");
-    let b_shape = shapes.get(&b_placed.module).expect("def block missing");
-    let abs_shape = b_shape.apply_transform(&b_placed.transform);
+    let abs_shape = block
+        .get_shape()
+        .unwrap()
+        .apply_transform(&b_placed.transform);
     assert_eq!(
         abs_shape,
-        RectilinearShape::new(vec![
+        Polygon::new(vec![
             (10, 20).into(),
             (110, 20).into(),
             (110, 220).into(),
@@ -81,15 +85,17 @@ fn placement_relative_basic() {
     i_inst.place((56, 78), Orientation::MY);
 
     // Compute placements and verify absolute shape
-    let (placements, shapes) = top.collect_placements_and_shapes();
+    let (placements, _) = top.collect_placements_and_mod_defs();
     let b_placed = placements
         .get("top/i_inst_0/b_inst_0")
         .expect("instance top/i_inst_0/b_inst_0 not found");
-    let b_shape = shapes.get(&b_placed.module).expect("def block missing");
-    let abs_shape = b_shape.apply_transform(&b_placed.transform);
+    let abs_shape = block
+        .get_shape()
+        .unwrap()
+        .apply_transform(&b_placed.transform);
     assert_eq!(
         abs_shape,
-        RectilinearShape::new(vec![
+        Polygon::new(vec![
             (44, 112).into(),
             (44, 12).into(),
             (-156, 12).into(),
@@ -124,20 +130,19 @@ fn placement_relative_to_parent() {
     }
 
     // Compute placements and verify absolute shape
-    let (placements, shapes) = top.collect_placements_and_shapes();
+    let (placements, _) = top.collect_placements_and_mod_defs();
 
     let b_placed: std::collections::HashMap<_, _> = placements
         .iter()
         .map(|(inst_name, p)| {
-            let b_shape = shapes.get(&p.module).expect("def block missing");
-            let abs_shape = b_shape.apply_transform(&p.transform);
+            let abs_shape = block.get_shape().unwrap().apply_transform(&p.transform);
             (inst_name.clone(), abs_shape)
         })
         .collect();
 
     assert_eq!(
         b_placed.get("top/i_inst_0/b_inst_0"),
-        Some(&RectilinearShape::new(vec![
+        Some(&Polygon::new(vec![
             (100, 200).into(),
             (500, 200).into(),
             (500, 500).into(),
@@ -147,7 +152,7 @@ fn placement_relative_to_parent() {
 
     assert_eq!(
         b_placed.get("top/i_inst_1/b_inst_0"),
-        Some(&RectilinearShape::new(vec![
+        Some(&Polygon::new(vec![
             (100, -200).into(),
             (500, -200).into(),
             (500, -500).into(),
@@ -157,7 +162,7 @@ fn placement_relative_to_parent() {
 
     assert_eq!(
         b_placed.get("top/i_inst_2/b_inst_0"),
-        Some(&RectilinearShape::new(vec![
+        Some(&Polygon::new(vec![
             (-100, -200).into(),
             (-500, -200).into(),
             (-500, -500).into(),
@@ -167,7 +172,7 @@ fn placement_relative_to_parent() {
 
     assert_eq!(
         b_placed.get("top/i_inst_3/b_inst_0"),
-        Some(&RectilinearShape::new(vec![
+        Some(&Polygon::new(vec![
             (-100, 200).into(),
             (-500, 200).into(),
             (-500, 500).into(),


### PR DESCRIPTION
This PR adds general (but very low-level) support for pinning. The basic low-level operation is to take a bit in a `ModDef` `Port` and give it:
1. A layer (`String`)
2. A position (`Coordinate`)
3. A shape (`Polygon`)

When LEFs are generated, they include this information.

This PR does not contain any notion of tracks, bus-level placement, connectivity-driven pinning, etc. These higher-level features will be explored in future PRs, and will build off the low-level pinning feature in this PR.

For an example of low-level pinning, see `examples/pinning.rs`, which produces the following layout:

<img width="838" height="231" alt="image" src="https://github.com/user-attachments/assets/50bcd714-ee1e-470b-b553-f2cbc130fe34" />
