### PR TITLE
Initial features for placing pins on tracks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,16 +1700,18 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cargo_metadata",
  "curl",
  "env_logger",
+ "fixedbitset",
  "indexmap",
  "itertools",
  "log",
  "nalgebra",
  "num-bigint",
+ "paste",
  "regex",
  "semver",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"
@@ -16,6 +16,8 @@ slang-rs = "0.21.0"
 itertools = "0.10"
 regex = "1.11.0"
 nalgebra = { version = "0.32", default-features = false, features = ["macros"] }
+fixedbitset = "0.5.7"
+paste = "1.0.15"
 
 [dev-dependencies]
 cargo_metadata = "0.18"

--- a/examples/pin_range_example.rs
+++ b/examples/pin_range_example.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use topstitch::{
+    BoundingBox, LefDefOptions, ModDef, Polygon, Range, TrackDefinition, TrackDefinitions,
+    TrackOrientation, IO,
+};
+
+const NUM_BITS: usize = 5;
+const MODULE_HEIGHT: i64 = 200;
+const MODULE_WIDTH: i64 = 200;
+const TRACK_PITCH: i64 = 20;
+const PIN_WIDTH: i64 = TRACK_PITCH / 2;
+const PIN_DEPTH: i64 = 20;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Paths for output files under examples/output
+    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let out_dir = examples.join("output");
+    std::fs::create_dir_all(&out_dir).expect("create examples/output/");
+
+    let m = ModDef::new("SpreadPins");
+
+    // Track definitions
+    let pin_shape = Polygon::from_bbox(&BoundingBox {
+        min_x: 0,
+        min_y: -PIN_WIDTH / 2,
+        max_x: PIN_DEPTH,
+        max_y: PIN_WIDTH / 2,
+    });
+
+    let mut track_definitions = TrackDefinitions::new();
+    let tracks = [
+        ("M1", TRACK_PITCH / 2, TrackOrientation::Horizontal),
+        ("M2", TRACK_PITCH / 2, TrackOrientation::Vertical),
+        ("M3", 3 * TRACK_PITCH / 4, TrackOrientation::Horizontal),
+        ("M4", 3 * TRACK_PITCH / 4, TrackOrientation::Vertical),
+    ];
+
+    for (name, offset, orientation) in tracks {
+        track_definitions.add_track(TrackDefinition::new(
+            name,
+            offset,
+            TRACK_PITCH,
+            orientation,
+            Some(pin_shape.clone()),
+            None,
+        ));
+    }
+
+    // Define module geometry and apply track definitions
+    m.set_shape(Polygon::from_width_height(MODULE_WIDTH, MODULE_HEIGHT));
+    m.set_track_definitions(track_definitions);
+
+    // Define ports
+    let in_left = m.add_port("in_left", IO::Input(NUM_BITS));
+    let out_right = m.add_port("out_right", IO::Output(NUM_BITS));
+    let in_top = m.add_port("in_top", IO::Input(NUM_BITS));
+    let out_bottom = m.add_port("out_bottom", IO::Output(NUM_BITS));
+
+    let layers = m.get_layers();
+
+    // Variety of different mechanisms shown for spreading pins on edges
+    in_left.spread_pins_on_left_edge(&layers, Range::from_min(MODULE_HEIGHT / 2))?;
+    m.spread_pins_on_right_edge(&out_right.to_bits(), &layers, Range::any())?;
+    in_top.spread_pins_on_top_edge(&layers, Range::new(MODULE_WIDTH / 4, 3 * MODULE_WIDTH / 4))?;
+    out_bottom
+        .spread_pins_on_bottom_edge(&layers, Range::new(MODULE_WIDTH / 4, 3 * MODULE_WIDTH / 4))?;
+
+    // Emit LEF for viewing
+    let lef_path = out_dir.join("pin_range_example.lef");
+    m.emit_lef_to_file(&lef_path, &LefDefOptions::default())
+        .expect("emit LEF");
+
+    Ok(())
+}

--- a/examples/pinning.rs
+++ b/examples/pinning.rs
@@ -1,68 +1,82 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
-use topstitch::{BoundingBox, LefDefOptions, Mat3, ModDef, Orientation, Polygon, Usage, IO};
+use topstitch::{
+    BoundingBox, LefDefOptions, ModDef, Orientation, Polygon, Range, TrackDefinition,
+    TrackDefinitions, TrackOrientation, Usage, IO,
+};
 
-const A_WIDTH: i64 = 100;
+const A_WIDTH: i64 = 50;
 const A_NUM_PINS: usize = 4;
 const B_NUM_PINS: usize = 8;
 const C_NUM_PINS: usize = 2;
 const TOTAL_PINS: usize = B_NUM_PINS;
-const B_WIDTH: i64 = 300;
-const C_WIDTH: i64 = 200;
-const PIN_LAYER: &str = "M1";
+const B_WIDTH: i64 = 150;
+const C_WIDTH: i64 = 100;
 const PIN_WIDTH: i64 = 10;
 const PIN_DEPTH: i64 = 20;
 
 // Build a simple leaf module with pins on the left and right edges.
-fn build_leaf(name: &str, width: i64, num_pins: usize) -> ModDef {
+fn build_leaf(
+    name: &str,
+    width: i64,
+    num_pins: usize,
+    track_definitions: &TrackDefinitions,
+) -> Result<ModDef, Box<dyn std::error::Error>> {
     // Define the module
     let m = ModDef::new(name);
     m.set_shape(Polygon::from_width_height(
         width,
-        2 * (num_pins as i64) * PIN_WIDTH,
+        (num_pins as i64) * PIN_WIDTH,
     ));
+    m.set_track_definitions(track_definitions.clone());
     m.set_layer(format!("OUTLINE_{}", name.to_uppercase()));
 
     // Input and output ports
     m.add_port("in", IO::Input(num_pins));
     m.add_port("out", IO::Output(num_pins));
 
-    // Define pin shape
+    // Pin inputs and outputs
+    let layers = m.get_layers();
+    m.get_port("in")
+        .spread_pins_on_left_edge(&layers, Range::any())?;
+    m.get_port("out")
+        .spread_pins_on_right_edge(&layers, Range::any())?;
+
+    // Mark as a leaf for LEF/DEF emission
+    m.set_usage(Usage::EmitStubAndStop);
+    Ok(m)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Paths for output files under examples/output
+    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let out_dir = examples.join("output");
+    std::fs::create_dir_all(&out_dir).expect("create examples/output/");
+
+    // Track definitions
+    let mut track_definitions = TrackDefinitions::new();
     let pin_shape = Polygon::from_bbox(&BoundingBox {
         min_x: 0,
         min_y: -PIN_WIDTH / 2,
         max_x: PIN_DEPTH,
         max_y: PIN_WIDTH / 2,
     });
-
-    // Define input pins on left edge (layer M1)
-    let flipped = pin_shape.apply_transform(&Mat3::from_orientation(Orientation::MY));
-    for i in 0..num_pins {
-        let y = PIN_WIDTH + (i as i64) * (2 * PIN_WIDTH);
-        m.get_port("in")
-            .bit(i)
-            .define_physical_pin(PIN_LAYER, (0, y).into(), pin_shape.clone());
-        m.get_port("out")
-            .bit(i)
-            .define_physical_pin(PIN_LAYER, (width, y).into(), flipped.clone());
+    for layer in 0..2 {
+        track_definitions.add_track(TrackDefinition::new(
+            format!("M{}", layer + 1),
+            PIN_WIDTH,
+            2 * PIN_WIDTH,
+            TrackOrientation::Horizontal,
+            Some(pin_shape.clone()),
+            None,
+        ));
     }
 
-    // Mark as a leaf for LEF/DEF emission
-    m.set_usage(Usage::EmitStubAndStop);
-    m
-}
-
-fn main() {
-    // Paths for output files under examples/output
-    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
-    let out_dir = examples.join("output");
-    std::fs::create_dir_all(&out_dir).expect("create examples/output/");
-
     // Build A, B, and C modules
-    let a = build_leaf("A", A_WIDTH, A_NUM_PINS);
-    let b = build_leaf("B", B_WIDTH, B_NUM_PINS);
-    let c = build_leaf("C", C_WIDTH, C_NUM_PINS);
+    let a = build_leaf("A", A_WIDTH, A_NUM_PINS, &track_definitions)?;
+    let b = build_leaf("B", B_WIDTH, B_NUM_PINS, &track_definitions)?;
+    let c = build_leaf("C", C_WIDTH, C_NUM_PINS, &track_definitions)?;
 
     let a_height = a.bbox().unwrap().get_height();
     let c_height = c.bbox().unwrap().get_height();
@@ -92,4 +106,6 @@ fn main() {
     let def_path = out_dir.join("pinning.def");
     top.emit_lef_def_to_files(&lef_path, &def_path, &LefDefOptions::default())
         .expect("emit LEF/DEF");
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,11 @@ mod mod_def;
 use mod_def::ModDefCore;
 pub use mod_def::ParameterType;
 pub use mod_def::{
-    BoundingBox, CalculatedPlacement, Coordinate, Mat3, Orientation, Placement, Polygon,
+    BoundingBox, CalculatedPlacement, ConvertibleToModDef, Coordinate, Mat3, ModDef, Orientation,
+    Placement, Polygon, Range, TrackDefinition, TrackDefinitions, TrackOrientation,
+    BOTTOM_EDGE_INDEX, EAST_EDGE_INDEX, LEFT_EDGE_INDEX, NORTH_EDGE_INDEX, RIGHT_EDGE_INDEX,
+    SOUTH_EDGE_INDEX, TOP_EDGE_INDEX, WEST_EDGE_INDEX,
 };
-pub use mod_def::{ConvertibleToModDef, ModDef};
 pub mod lefdef;
 pub use lefdef::LefDefOptions;
 

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -12,7 +12,7 @@ pub use core::ModDefCore;
 
 mod dtypes;
 pub(crate) use dtypes::{Assignment, InstConnection, PortSliceOrWire, Wire};
-pub use dtypes::{BoundingBox, Coordinate, Mat3, Orientation, Placement, Polygon};
+pub use dtypes::{BoundingBox, Coordinate, Edge, Mat3, Orientation, Placement, Polygon, Range};
 
 mod emit;
 mod feedthrough;
@@ -34,11 +34,55 @@ mod wrap;
 use parser::{parser_param_to_param, parser_port_to_port};
 mod abutment;
 mod hierarchy;
+mod tracks;
+pub use tracks::{TrackDefinition, TrackDefinitions, TrackOrientation};
+use tracks::{TrackOccupancies, TrackOccupancy};
+mod edges;
+mod shape;
+pub use edges::{
+    BOTTOM_EDGE_INDEX, EAST_EDGE_INDEX, LEFT_EDGE_INDEX, NORTH_EDGE_INDEX, RIGHT_EDGE_INDEX,
+    SOUTH_EDGE_INDEX, TOP_EDGE_INDEX, WEST_EDGE_INDEX,
+};
+
 /// Represents a module definition, like `module <mod_def_name> ... endmodule`
 /// in Verilog.
 #[derive(Clone)]
 pub struct ModDef {
     pub(crate) core: Rc<RefCell<ModDefCore>>,
+}
+
+#[macro_export]
+macro_rules! for_each_edge_direction {
+    ($macro_name:ident) => {
+        $macro_name!(west, $crate::mod_def::WEST_EDGE_INDEX);
+        $macro_name!(left, $crate::mod_def::LEFT_EDGE_INDEX);
+        $macro_name!(north, $crate::mod_def::NORTH_EDGE_INDEX);
+        $macro_name!(top, $crate::mod_def::TOP_EDGE_INDEX);
+        $macro_name!(east, $crate::mod_def::EAST_EDGE_INDEX);
+        $macro_name!(right, $crate::mod_def::RIGHT_EDGE_INDEX);
+        $macro_name!(south, $crate::mod_def::SOUTH_EDGE_INDEX);
+        $macro_name!(bottom, $crate::mod_def::BOTTOM_EDGE_INDEX);
+    };
+}
+
+macro_rules! define_keepout_on_named_edge {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Marks the specified tracks on the ",
+                stringify!($edge_name),
+                " edge as a keepout region using the provided polygon."
+            )]
+            pub fn [<define_keepout_on_ $edge_name _edge>](
+                &self,
+                layer: impl AsRef<str>,
+                track_index: usize,
+                polygon: &Polygon,
+            ) {
+                self.define_keepout_on_edge_index($const_name, layer, track_index, polygon);
+            }
+        }
+    };
 }
 
 impl ModDef {
@@ -67,6 +111,8 @@ impl ModDef {
                 layer: None,
                 inst_placements: IndexMap::new(),
                 physical_pins: IndexMap::new(),
+                track_definitions: None,
+                track_occupancies: None,
             })),
         }
     }
@@ -104,9 +150,18 @@ impl ModDef {
     pub fn set_shape(&self, shape: Polygon) {
         assert!(
             shape.is_rectilinear(),
-            "Only rectilinear polygons are supported"
+            "A ModDef shape must be rectilinear."
+        );
+        assert!(
+            shape.is_clockwise(),
+            "ModDef shape edges must be defined in a clockwise order."
+        );
+        assert!(
+            shape.starts_with_leftmost_vertical_edge(),
+            "ModDef shapes must start with the leftmost vertical edge."
         );
         let mut core = self.core.borrow_mut();
+        core.track_occupancies = Some(TrackOccupancies::new(shape.num_edges()));
         core.shape = Some(shape);
     }
 
@@ -124,6 +179,170 @@ impl ModDef {
     /// Returns this module's layer, if defined.
     pub fn get_layer(&self) -> Option<String> {
         self.core.borrow().layer.clone()
+    }
+
+    /// Returns the number of edges (vertices) of the current shape, if set.
+    pub fn get_num_edges(&self) -> usize {
+        self.core
+            .borrow()
+            .shape
+            .as_ref()
+            .map(|s| s.num_edges())
+            .unwrap_or(0)
+    }
+
+    /// Sets the track definitions for this module.
+    pub fn set_track_definitions(&self, track_definitions: TrackDefinitions) {
+        let mut core = self.core.borrow_mut();
+        let shape = core
+            .shape
+            .as_ref()
+            .expect("Shape must be set before setting track definitions")
+            .clone();
+        core.track_definitions = Some(track_definitions);
+
+        // For each edge, for each track definition (layer), initialize occupancy
+        let track_defs = core.track_definitions.as_ref().unwrap().clone();
+        let occupancies = core
+            .track_occupancies
+            .as_mut()
+            .expect("Track occupancies must be initialized before setting track definitions");
+
+        for (edge_index, edge_map) in occupancies.0.iter_mut().enumerate() {
+            let edge = shape.get_edge(edge_index);
+            for (layer_name, track_def) in track_defs.0.iter() {
+                if let Some(range) = edge.get_index_range(track_def) {
+                    let length = (range.max.unwrap() - range.min.unwrap() + 1) as usize;
+                    edge_map.insert(layer_name.clone(), TrackOccupancy::new(length));
+                }
+            }
+        }
+    }
+
+    /// Looks up the [`TrackDefinition`] for `name`, if one has been registered.
+    pub fn get_track(&self, name: impl AsRef<str>) -> Option<TrackDefinition> {
+        let core_borrowed = self.core.borrow();
+        let track_definitions = &core_borrowed.track_definitions;
+        track_definitions
+            .as_ref()
+            .and_then(|t| t.get_track(name.as_ref()).cloned())
+    }
+
+    /// Returns the polygon edge at `edge_index`, or `None` if the shape is not
+    /// defined or the index is out of bounds.
+    pub fn get_edge(&self, edge_index: usize) -> Option<Edge> {
+        let core_borrowed = self.core.borrow();
+        let shape = &core_borrowed.shape;
+        shape.as_ref().map(|s| s.get_edge(edge_index))
+    }
+
+    /// Marks the inclusive track index range as occupied by an existing pin.
+    pub fn mark_pin_range(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        min_index: i64,
+        max_index: i64,
+    ) {
+        let mut core = self.core.borrow_mut();
+        let occupancies = core
+            .track_occupancies
+            .as_mut()
+            .expect("Track occupancies not initialized");
+        if let Some(occupancy) = occupancies.get_occupancy_mut(edge_index, layer.as_ref()) {
+            occupancy.mark_pin(min_index, max_index);
+        }
+    }
+
+    /// Marks the inclusive track index range as blocked by a keepout region.
+    pub fn mark_keepout_range(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        min_index: i64,
+        max_index: i64,
+    ) {
+        let mut core = self.core.borrow_mut();
+        let occupancies = core
+            .track_occupancies
+            .as_mut()
+            .expect("Track occupancies not initialized");
+        if let Some(occupancy) = occupancies.get_occupancy_mut(edge_index, layer.as_ref()) {
+            occupancy.mark_keepout(min_index, max_index);
+        }
+    }
+
+    /// Records both the pin and the keepout envelopes for a placed pin in a
+    /// single call.
+    pub fn mark_pin_and_keepout_ranges(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        pin_min_index: i64,
+        pin_max_index: i64,
+        keepout_min_index: i64,
+        keepout_max_index: i64,
+    ) {
+        let mut core = self.core.borrow_mut();
+        let occupancies = core
+            .track_occupancies
+            .as_mut()
+            .expect("Track occupancies not initialized");
+        if let Some(occupancy) = occupancies.get_occupancy_mut(edge_index, layer.as_ref()) {
+            occupancy.place_pin_and_keepout(
+                pin_min_index,
+                pin_max_index,
+                keepout_min_index,
+                keepout_max_index,
+            );
+        }
+    }
+
+    for_each_edge_direction!(define_keepout_on_named_edge);
+
+    /// Marks the keepout polygon corresponding to `track_index` on
+    /// `edge_index`, using the provided shape to derive track coverage.
+    pub fn define_keepout_on_edge_index(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+        polygon: &Polygon,
+    ) {
+        let layer_ref = layer.as_ref();
+
+        let (keepout_min_track, keepout_max_track) =
+            self.track_range_for_polygon(layer_ref, track_index, polygon);
+
+        self.mark_keepout_range(edge_index, layer_ref, keepout_min_track, keepout_max_track);
+    }
+
+    /// Returns the ordered list of routing layer names with defined track
+    /// families.
+    pub fn get_layers(&self) -> Vec<String> {
+        self.core
+            .borrow()
+            .track_definitions
+            .as_ref()
+            .map(|td| td.0.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Fetches a clone of the occupancy bitmap for internal placement checks.
+    pub(crate) fn get_occupancy(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+    ) -> Option<TrackOccupancy> {
+        self.core
+            .borrow()
+            .track_occupancies
+            .as_ref()
+            .and_then(|occupancies| {
+                occupancies
+                    .get_occupancy(edge_index, layer.as_ref())
+                    .cloned()
+            })
     }
 }
 

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 use num_bigint::BigInt;
 
 use crate::mod_def::dtypes::{PhysicalPin, VerilogImport};
+use crate::mod_def::tracks::{TrackDefinitions, TrackOccupancies};
 
 pub(crate) use crate::mod_def::{Assignment, InstConnection, Wire};
 use crate::{PortSlice, Usage, IO};
@@ -41,4 +42,6 @@ pub struct ModDefCore {
     pub(crate) layer: Option<String>,
     pub(crate) inst_placements: IndexMap<String, crate::mod_def::dtypes::Placement>,
     pub(crate) physical_pins: PhysicalPinMap,
+    pub(crate) track_definitions: Option<TrackDefinitions>,
+    pub(crate) track_occupancies: Option<TrackOccupancies>,
 }

--- a/src/mod_def/edges.rs
+++ b/src/mod_def/edges.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub const WEST_EDGE_INDEX: usize = 0;
+pub const LEFT_EDGE_INDEX: usize = 0;
+pub const NORTH_EDGE_INDEX: usize = 1;
+pub const TOP_EDGE_INDEX: usize = 1;
+pub const EAST_EDGE_INDEX: usize = 2;
+pub const RIGHT_EDGE_INDEX: usize = 2;
+pub const SOUTH_EDGE_INDEX: usize = 3;
+pub const BOTTOM_EDGE_INDEX: usize = 3;

--- a/src/mod_def/lefdef.rs
+++ b/src/mod_def/lefdef.rs
@@ -10,78 +10,31 @@ use crate::mod_def::CalculatedPlacement;
 use crate::{LefDefOptions, ModDef, Polygon};
 
 impl ModDef {
+    /// Emit a LEF string describing this module's geometry and pins.
+    pub fn emit_lef(&self, opts: &LefDefOptions) -> String {
+        let component = self.to_lef_component();
+        lefdef::generate_lef(&[component], opts)
+    }
+
+    /// Emit a LEF file for this module.
+    pub fn emit_lef_to_file<P: AsRef<Path>>(
+        &self,
+        lef_path: P,
+        opts: &LefDefOptions,
+    ) -> std::io::Result<()> {
+        let lef = self.emit_lef(opts);
+        fs::write(lef_path, lef)
+    }
+
     /// Emit LEF and DEF strings for this module using collected shapes and
     /// placements. Returns (lef_string, def_string).
     pub fn emit_lef_def(&self, opts: &LefDefOptions) -> (String, String) {
         let (placements, mod_defs) = self.collect_placements_and_mod_defs();
         // Build components directly from referenced ModDefs
-        let mut lef_components: IndexMap<String, LefComponent> = IndexMap::new();
-        for (name, md) in mod_defs.iter() {
-            let core = md.core.borrow();
-            let shape = core.shape.as_ref().unwrap_or_else(|| {
-                panic!("Module '{}' marked to stop but has no shape defined", name)
-            });
-            let bbox = shape.bbox();
-            assert!(bbox.min_x >= 0, "LEFs do not support negative coordinates");
-            assert!(bbox.min_y >= 0, "LEFs do not support negative coordinates");
-
-            // Construct LEF pins from physical_pins in a deterministic order
-            let mut lef_pins = Vec::new();
-            for (port_name, pins) in core.physical_pins.iter() {
-                let port = core.ports.get(port_name).unwrap_or_else(|| {
-                    panic!(
-                        "Physical pin defined for unknown port {}.{}",
-                        core.name, port_name
-                    )
-                });
-                let direction = match port {
-                    crate::IO::Input(_) => "INPUT",
-                    crate::IO::Output(_) => "OUTPUT",
-                    crate::IO::InOut(_) => "INOUT",
-                }
-                .to_string();
-
-                for (bit, maybe_pin) in pins.iter().enumerate() {
-                    if let Some(pin) = maybe_pin {
-                        let name = format!("{}[{}]", &port_name, bit);
-                        let polygon_abs: Vec<(i64, i64)> = pin
-                            .polygon
-                            .0
-                            .iter()
-                            .map(|c| (c.x + pin.position.x, c.y + pin.position.y))
-                            .collect();
-                        lef_pins.push(crate::lefdef::LefPin {
-                            name,
-                            direction: direction.clone(),
-                            shape: crate::lefdef::LefShape {
-                                layer: pin.layer.clone(),
-                                polygon: polygon_abs,
-                            },
-                        });
-                    }
-                }
-            }
-
-            let layer_name = core
-                .layer
-                .as_ref()
-                .cloned()
-                .unwrap_or_else(|| "OUTLINE".to_string());
-
-            lef_components.insert(
-                name.clone(),
-                LefComponent {
-                    name: name.clone(),
-                    width: bbox.max_x,
-                    height: bbox.max_y,
-                    shape: crate::lefdef::LefShape {
-                        layer: layer_name,
-                        polygon: shape.0.iter().map(|p| (p.x, p.y)).collect(),
-                    },
-                    pins: lef_pins,
-                },
-            );
-        }
+        let lef_components: IndexMap<String, LefComponent> = mod_defs
+            .iter()
+            .map(|(name, md)| (name.clone(), md.to_lef_component()))
+            .collect();
 
         let def_components = placements_to_def_components(&placements, &lef_components);
 
@@ -104,6 +57,74 @@ impl ModDef {
         fs::write(lef_path, lef)?;
         fs::write(def_path, def)?;
         Ok(())
+    }
+}
+
+impl ModDef {
+    fn to_lef_component(&self) -> LefComponent {
+        let core = self.core.borrow();
+        let name = core.name.clone();
+        let shape = core
+            .shape
+            .as_ref()
+            .unwrap_or_else(|| panic!("Module '{}' has no shape defined", name));
+        let bbox = shape.bbox();
+        assert!(bbox.min_x >= 0, "LEFs do not support negative coordinates");
+        assert!(bbox.min_y >= 0, "LEFs do not support negative coordinates");
+
+        // Construct LEF pins from physical_pins in a deterministic order
+        let mut lef_pins = Vec::new();
+        for (port_name, pins) in core.physical_pins.iter() {
+            let port = core.ports.get(port_name).unwrap_or_else(|| {
+                panic!(
+                    "Physical pin defined for unknown port {}.{}",
+                    core.name, port_name
+                )
+            });
+            let direction = match port {
+                crate::IO::Input(_) => "INPUT",
+                crate::IO::Output(_) => "OUTPUT",
+                crate::IO::InOut(_) => "INOUT",
+            }
+            .to_string();
+
+            for (bit, maybe_pin) in pins.iter().enumerate() {
+                if let Some(pin) = maybe_pin {
+                    let name = format!("{}[{}]", &port_name, bit);
+                    let polygon_abs: Vec<(i64, i64)> = pin
+                        .polygon
+                        .0
+                        .iter()
+                        .map(|c| (c.x + pin.position.x, c.y + pin.position.y))
+                        .collect();
+                    lef_pins.push(crate::lefdef::LefPin {
+                        name,
+                        direction: direction.clone(),
+                        shape: crate::lefdef::LefShape {
+                            layer: pin.layer.clone(),
+                            polygon: polygon_abs,
+                        },
+                    });
+                }
+            }
+        }
+
+        let layer_name = core
+            .layer
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| "OUTLINE".to_string());
+
+        LefComponent {
+            name,
+            width: bbox.max_x,
+            height: bbox.max_y,
+            shape: crate::lefdef::LefShape {
+                layer: layer_name,
+                polygon: shape.0.iter().map(|p| (p.x, p.y)).collect(),
+            },
+            pins: lef_pins,
+        }
     }
 }
 

--- a/src/mod_def/parameterize.rs
+++ b/src/mod_def/parameterize.rs
@@ -299,6 +299,8 @@ impl ModDef {
                 layer: None,
                 inst_placements: IndexMap::new(),
                 physical_pins: IndexMap::new(),
+                track_definitions: None,
+                track_occupancies: None,
             })),
         }
     }

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -129,6 +129,8 @@ impl ModDef {
                 layer: None,
                 inst_placements: IndexMap::new(),
                 physical_pins: IndexMap::new(),
+                track_definitions: None,
+                track_occupancies: None,
             })),
         }
     }

--- a/src/mod_def/pins.rs
+++ b/src/mod_def/pins.rs
@@ -1,19 +1,816 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use indexmap::map::Entry;
+use indexmap::{map::Entry, IndexMap};
+use std::collections::{HashMap, HashSet};
 
-use crate::mod_def::dtypes::{Coordinate, PhysicalPin, Polygon};
-use crate::PortSlice;
+use crate::mod_def::dtypes::{Coordinate, PhysicalPin, Polygon, Range};
+use crate::{for_each_edge_direction, ModDef, Port, PortSlice};
 
-impl PortSlice {
+macro_rules! place_pin_on_named_edge {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+                #[doc = concat!(
+                    "Places the specified pin bit on the ",
+                    stringify!($edge_name),
+                    " edge using the default track definition."
+                )]
+                pub fn [<place_pin_on_ $edge_name _edge>](
+                &self,
+                port_name: impl AsRef<str>,
+                bit: usize,
+                layer: impl AsRef<str>,
+                track_index: usize
+            ) {
+                assert!(
+                    self.shape_is_rectangular(),
+                    "Cannot use cardinal direction names for edges for a non-rectangular shape"
+                );
+                self.place_pin_on_edge_index(port_name, bit, $const_name, layer, track_index);
+            }
+        }
+    };
+}
+
+macro_rules! place_pins_on_named_edge_index {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Places the provided pins on the ",
+                stringify!($edge_name),
+                " edge while honoring optional spacing and layer priorities."
+            )]
+            pub fn [<place_pins_on_ $edge_name _edge>]<L, S>(
+                &self,
+                pins: &[(impl AsRef<str>, usize)],
+                layers: L,
+                position_range: Range,
+                min_spacing: Option<i64>,
+            ) -> Result<(), BatchPinPlacementError>
+            where
+                L: IntoIterator<Item = S>,
+                S: AsRef<str>,
+            {
+                self.place_pins_on_edge_index(
+                    pins,
+                    $const_name,
+                    layers,
+                    position_range,
+                    min_spacing,
+                )
+            }
+        }
+    };
+}
+
+macro_rules! place_pins_on_named_edge_index_with_polygons {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Places the provided pins on the ",
+                stringify!($edge_name),
+                " edge using explicit pin and keepout polygons per layer."
+            )]
+            pub fn [<place_pins_on_ $edge_name _edge_with_polygons>](
+                &self,
+                pins: &[(impl AsRef<str>, usize)],
+                layers: IndexMap<String, (Polygon, Option<Polygon>)>,
+                position_range: Range,
+                min_spacing: Option<i64>,
+            ) -> Result<(), BatchPinPlacementError> {
+                self.place_pins_on_edge_index_with_polygons(
+                    pins,
+                    $const_name,
+                    layers,
+                    position_range,
+                    min_spacing,
+                )
+            }
+        }
+    };
+}
+
+macro_rules! spread_pins_on_named_edge_index {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Evenly spreads the provided pins across the ",
+                stringify!($edge_name),
+                " edge using layer defaults."
+            )]
+            pub fn [<spread_pins_on_ $edge_name _edge>]<L, S>(
+                &self,
+                pins: &[(impl AsRef<str>, usize)],
+                layers: L,
+                position_range: Range,
+            ) -> Result<(), BatchPinPlacementError>
+            where
+                L: IntoIterator<Item = S>,
+                S: AsRef<str>,
+            {
+                self.spread_pins_on_edge_index(
+                    pins,
+                    $const_name,
+                    layers,
+                    position_range,
+                )
+            }
+        }
+    };
+}
+
+macro_rules! spread_pins_on_named_edge_index_with_polygons {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Evenly spreads the provided pins across the ",
+                stringify!($edge_name),
+                " edge using custom per-layer pin polygons."
+            )]
+            pub fn [<spread_pins_on_ $edge_name _edge_with_polygons>](
+                &self,
+                pins: &[(impl AsRef<str>, usize)],
+                layers: IndexMap<String, (Polygon, Option<Polygon>)>,
+                position_range: Range,
+            ) -> Result<(), BatchPinPlacementError> {
+                self.spread_pins_on_edge_index_with_polygons(
+                    pins,
+                    $const_name,
+                    layers,
+                    position_range,
+                )
+            }
+        }
+    };
+}
+
+macro_rules! spread_port_pins_on_named_edge {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            impl Port {
+                #[doc = concat!(
+                    "Spreads the bits of this port on the ",
+                    stringify!($edge_name),
+                    " edge using layer defaults."
+                )]
+                pub fn [<spread_pins_on_ $edge_name _edge>]<L, S>(
+                    &self,
+                    layers: L,
+                    position_range: Range,
+                ) -> Result<(), BatchPinPlacementError>
+                where
+                    L: IntoIterator<Item = S>,
+                    S: AsRef<str>,
+                {
+                    let mod_def = ModDef { core: self.get_mod_def_core() };
+                    mod_def.[<spread_pins_on_ $edge_name _edge>](&self.to_bits(), layers, position_range)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! spread_port_slice_pins_on_named_edge {
+    ($edge_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Spreads the bits of this `PortSlice` on the ",
+                stringify!($edge_name),
+                " edge using layer defaults."
+            )]
+            pub fn [<spread_pins_on_ $edge_name _edge>]<L, S>(
+                &self,
+                layers: L,
+                position_range: Range,
+            ) -> Result<(), BatchPinPlacementError>
+            where
+                L: IntoIterator<Item = S>,
+                S: AsRef<str>,
+            {
+                self.get_mod_def().[<spread_pins_on_ $edge_name _edge>](
+                    &self.to_bits(),
+                    layers,
+                    position_range,
+                )
+            }
+        }
+    };
+}
+
+/// Describes why a batch pin placement request could not be satisfied.
+#[derive(Debug, Clone)]
+pub enum BatchPinPlacementError {
+    /// There were more pins than available layer slots.
+    RanOutOfLayers { requested: usize, placed: usize },
+    /// The selected edge index was not valid for the current shape.
+    EdgeOutOfBounds { edge_index: usize, num_edges: usize },
+    /// The requested coordinate window falls outside the selected edge span.
+    RequestOutOfBounds {
+        edge_index: usize,
+        edge_range: Range,
+        req_range: Range,
+    },
+    /// The requested track indices fell outside the layer coverage for the
+    /// edge.
+    OffTrackRange {
+        layer: String,
+        req_range: Range,
+        edge_range: Range,
+    },
+}
+
+impl std::fmt::Display for BatchPinPlacementError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BatchPinPlacementError::RanOutOfLayers { requested, placed } => write!(
+                f,
+                "unable to place all pins: requested {}, placed {} (ran out of layers)",
+                requested, placed
+            ),
+            BatchPinPlacementError::EdgeOutOfBounds {
+                edge_index,
+                num_edges,
+            } => write!(
+                f,
+                "edge index {} is out of bounds ({} edges available)",
+                edge_index, num_edges
+            ),
+            BatchPinPlacementError::RequestOutOfBounds {
+                edge_index,
+                edge_range,
+                req_range,
+            } => write!(
+                f,
+                "requested coordinate range {} on edge {} lies outside edge span {}",
+                req_range, edge_index, edge_range
+            ),
+            BatchPinPlacementError::OffTrackRange {
+                layer,
+                req_range,
+                edge_range,
+            } => write!(
+                f,
+                "requested absolute track range {} on layer '{}' lies outside edge coverage {}",
+                req_range, layer, edge_range
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BatchPinPlacementError {}
+
+impl ModDef {
+    /// Creates a scratch copy of the module for speculative placement checks.
+    fn clone_for_pin_placement(&self) -> ModDef {
+        use crate::mod_def::tracks::{TrackOccupancies, TrackOccupancy};
+        let core = self.core.borrow();
+
+        // Deep-copy track occupancies if present
+        let cloned_occupancies: Option<TrackOccupancies> =
+            core.track_occupancies.as_ref().map(|occ| {
+                let mut vec_maps: Vec<indexmap::IndexMap<String, TrackOccupancy>> =
+                    Vec::with_capacity(occ.0.len());
+                for edge_map in occ.0.iter() {
+                    let mut new_map = indexmap::IndexMap::new();
+                    for (layer, o) in edge_map.iter() {
+                        let mut no = TrackOccupancy::new(o.pin_occupancies.len());
+                        no.pin_occupancies = o.pin_occupancies.clone();
+                        no.keepout_occupancies = o.keepout_occupancies.clone();
+                        new_map.insert(layer.clone(), no);
+                    }
+                    vec_maps.push(new_map);
+                }
+                TrackOccupancies(vec_maps)
+            });
+
+        let new_core = crate::mod_def::ModDefCore {
+            name: core.name.clone(),
+            ports: core.ports.clone(),
+            interfaces: IndexMap::new(),
+            instances: IndexMap::new(),
+            usage: core.usage.clone(),
+            generated_verilog: None,
+            verilog_import: None,
+            assignments: Vec::new(),
+            unused: Vec::new(),
+            tieoffs: Vec::new(),
+            whole_port_tieoffs: IndexMap::new(),
+            whole_port_unused: IndexMap::new(),
+            inst_connections: IndexMap::new(),
+            reserved_net_definitions: core.reserved_net_definitions.clone(),
+            enum_ports: IndexMap::new(),
+            adjacency_matrix: HashMap::new(),
+            ignore_adjacency: HashSet::new(),
+            shape: core.shape.clone(),
+            layer: core.layer.clone(),
+            inst_placements: IndexMap::new(),
+            physical_pins: core.physical_pins.clone(),
+            track_definitions: core.track_definitions.clone(),
+            track_occupancies: cloned_occupancies,
+        };
+
+        ModDef {
+            core: std::rc::Rc::new(std::cell::RefCell::new(new_core)),
+        }
+    }
     /// Define a physical pin for this single-bit PortSlice, with an arbitrary
     /// polygon shape relative to `position` on the given `layer`.
-    pub fn define_physical_pin(
+    pub fn place_pin(
         &self,
+        port_name: impl AsRef<str>,
+        bit: usize,
         layer: impl AsRef<str>,
         position: Coordinate,
         polygon: Polygon,
     ) {
+        let mut core = self.core.borrow_mut();
+        let io = core.ports.get(port_name.as_ref()).unwrap_or_else(|| {
+            panic!(
+                "Port {}.{} does not exist (adding physical pin)",
+                self.core.borrow().name,
+                port_name.as_ref()
+            )
+        });
+        let width = io.width();
+        if bit >= width {
+            panic!(
+                "Bit {} out of range for port {}.{} with width {}",
+                bit,
+                self.core.borrow().name,
+                port_name.as_ref(),
+                width
+            );
+        }
+
+        // Ensure vector of appropriate width exists on first use
+        let pins_for_port = match core.physical_pins.entry(port_name.as_ref().to_string()) {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(v) => v.insert(vec![None; width]),
+        };
+
+        pins_for_port[bit] = Some(PhysicalPin {
+            layer: layer.as_ref().to_string(),
+            position,
+            polygon,
+        });
+    }
+
+    for_each_edge_direction!(place_pin_on_named_edge);
+    for_each_edge_direction!(place_pins_on_named_edge_index);
+    for_each_edge_direction!(place_pins_on_named_edge_index_with_polygons);
+    for_each_edge_direction!(spread_pins_on_named_edge_index);
+    for_each_edge_direction!(spread_pins_on_named_edge_index_with_polygons);
+
+    /// Define a physical pin for this single-bit `PortSlice` on a specific edge
+    /// by index, using the default pin/keepout shapes from the layer's
+    /// track definition.
+    pub fn place_pin_on_edge_index(
+        &self,
+        port_name: impl AsRef<str>,
+        bit: usize,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+    ) {
+        let track = self.get_track(layer.as_ref()).unwrap();
+        self.place_pin_on_edge_index_with_polygon(
+            port_name,
+            bit,
+            edge_index,
+            layer,
+            track_index,
+            track.pin_shape.as_ref(),
+            track.keepout_shape.as_ref(),
+        );
+    }
+
+    /// Define a physical pin for this single-bit `PortSlice` on a specific edge
+    /// by index, using the provided pin/keepout polygons (relative to the
+    /// track origin). Panics with a descriptive message if the placement is
+    /// not allowed.
+    #[allow(clippy::too_many_arguments)]
+    pub fn place_pin_on_edge_index_with_polygon(
+        &self,
+        port_name: impl AsRef<str>,
+        bit: usize,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+        pin_polygon: Option<&Polygon>,
+        keepout_polygon: Option<&Polygon>,
+    ) {
+        let layer_ref = layer.as_ref();
+
+        // Validate placement and surface a precise error message if disallowed
+        if let Err(err) = self.check_pin_placement_on_edge_index_with_polygon(
+            edge_index,
+            layer_ref,
+            track_index,
+            pin_polygon,
+            keepout_polygon,
+        ) {
+            panic!(
+                "Cannot place pin for {}.{}[{}] on edge {} (layer '{}', track {}): {}",
+                self.core.borrow().name,
+                port_name.as_ref(),
+                bit,
+                edge_index,
+                layer_ref,
+                track_index,
+                err
+            );
+        }
+
+        if let Some(pin_polygon) = pin_polygon {
+            let (pin_min_track, pin_max_track) =
+                self.track_range_for_polygon(layer_ref, track_index, pin_polygon);
+            if let Some(keepout_polygon) = keepout_polygon {
+                let (keepout_min_track, keepout_max_track) =
+                    self.track_range_for_polygon(layer_ref, track_index, keepout_polygon);
+                self.mark_pin_and_keepout_ranges(
+                    edge_index,
+                    layer_ref,
+                    pin_min_track,
+                    pin_max_track,
+                    keepout_min_track,
+                    keepout_max_track,
+                );
+            } else {
+                let (pin_min_track, pin_max_track) =
+                    self.track_range_for_polygon(layer_ref, track_index, pin_polygon);
+                self.mark_pin_range(edge_index, layer_ref, pin_min_track, pin_max_track);
+            }
+
+            let (position, transform) =
+                self.track_index_to_position_and_transform(edge_index, layer_ref, track_index);
+            let pin_polygon = pin_polygon.apply_transform(&transform);
+            self.place_pin(port_name, bit, layer_ref, position, pin_polygon);
+        } else if let Some(keepout_polygon) = keepout_polygon {
+            let (keepout_min_track, keepout_max_track) =
+                self.track_range_for_polygon(layer_ref, track_index, keepout_polygon);
+            self.mark_keepout_range(edge_index, layer_ref, keepout_min_track, keepout_max_track);
+        }
+    }
+
+    /// Places each `(port, bit)` on `edge_index` using `layers` in priority
+    /// order, optionally enforcing a minimum track spacing.
+    pub fn place_pins_on_edge_index<L, S>(
+        &self,
+        pins: &[(impl AsRef<str>, usize)],
+        edge_index: usize,
+        layers: L,
+        position_range: Range,
+        min_spacing: Option<i64>,
+    ) -> Result<(), BatchPinPlacementError>
+    where
+        L: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.place_pins_on_edge_index_with_polygons(
+            pins,
+            edge_index,
+            self.get_default_layer_shapes(layers),
+            position_range,
+            min_spacing,
+        )
+    }
+
+    /// Places each `(port, bit)` on `edge_index` using explicit pin/keepout
+    /// shapes provided per layer.
+    pub fn place_pins_on_edge_index_with_polygons(
+        &self,
+        pins: &[(impl AsRef<str>, usize)],
+        edge_index: usize,
+        layers: IndexMap<String, (Polygon, Option<Polygon>)>,
+        position_range: Range,
+        min_spacing: Option<i64>,
+    ) -> Result<(), BatchPinPlacementError> {
+        let mut placed_count: usize = 0;
+
+        // find range of coordinates for this edge
+        let edge = match self.get_edge(edge_index) {
+            Some(e) => e,
+            None => {
+                return Err(BatchPinPlacementError::EdgeOutOfBounds {
+                    edge_index,
+                    num_edges: self.get_num_edges(),
+                })
+            }
+        };
+        let edge_range = match edge.get_coord_range() {
+            Some(v) => v,
+            None => {
+                return Err(BatchPinPlacementError::EdgeOutOfBounds {
+                    edge_index,
+                    num_edges: self.get_num_edges(),
+                })
+            }
+        };
+        let edge_min = edge_range.min.unwrap();
+        let req_abs_range = Range {
+            min: position_range.min.map(|v| edge_min + v),
+            max: position_range.max.map(|v| edge_min + v),
+        };
+        if !req_abs_range.is_subset_of(&edge_range) {
+            return Err(BatchPinPlacementError::RequestOutOfBounds {
+                edge_index,
+                edge_range,
+                req_range: req_abs_range,
+            });
+        }
+
+        let req_range = req_abs_range;
+
+        // Build candidate list: (absolute param along edge, layer priority index, track
+        // index on edge)
+        struct Candidate {
+            position: i64,
+            layer_idx: usize,
+            track_index: usize,
+        }
+
+        let mut candidates: Vec<Candidate> = Vec::new();
+        let mut spacing_by_layer: Vec<Option<i64>> = Vec::new();
+
+        // Maintain a side table of layer names in insertion order
+        let layer_names: Vec<&str> = layers.keys().map(|k| k.as_str()).collect();
+
+        let edge_orientation = edge
+            .orientation()
+            .expect("Edge orientation must be rectilinear");
+        for (layer_idx, layer_name) in layer_names.iter().enumerate() {
+            // track def
+            let track = match self.get_track(layer_name) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            if !track
+                .orientation
+                .is_compatible_with_edge_orientation(&edge_orientation)
+            {
+                // need an empty entry for this layer to avoid offset in indices
+                spacing_by_layer.push(None);
+                continue;
+            }
+
+            // quantized request window to track indices within this edge coverage
+            let req_tracks = track.convert_coord_range_to_index_range(&req_range);
+            let edge_tracks = match edge.get_index_range(&track) {
+                Some(v) => v,
+                None => continue,
+            };
+            let edge_min_index = match edge_tracks.min {
+                Some(v) => v,
+                None => continue,
+            };
+            let (rel_min, rel_max) = match req_tracks.intersection(&edge_tracks) {
+                Some(Range {
+                    min: Some(min),
+                    max: Some(max),
+                }) => (min - edge_min_index, max - edge_min_index),
+                _ => continue,
+            };
+
+            assert!(rel_min >= 0);
+            let rel_min = rel_min as usize;
+
+            assert!(rel_max >= 0);
+            let rel_max = rel_max as usize;
+
+            // spacing expressed in tracks for this layer
+            let spacing_tracks =
+                min_spacing.map(|spacing| (spacing + track.period - 1) / track.period);
+            spacing_by_layer.push(spacing_tracks);
+
+            // Collect all candidate track indices in the requested window
+            // Candidate tracks are those not occupied by pins or keepouts
+            let track_occupancy = match self.get_occupancy(edge_index, layer_name) {
+                Some(v) => v,
+                None => continue,
+            };
+            candidates.extend(
+                track_occupancy
+                    .get_available_indices_in_range(rel_min, rel_max)
+                    .ones()
+                    .map(|track_index| {
+                        let position = edge.get_position_on_edge(&track, track_index);
+                        Candidate {
+                            position,
+                            layer_idx,
+                            track_index,
+                        }
+                    }),
+            );
+        }
+
+        // Sort by absolute param; tie-break by layer priority then track index
+        candidates.sort_by(|a, b| {
+            use std::cmp::Ordering;
+            match a.position.cmp(&b.position) {
+                Ordering::Equal => match a.layer_idx.cmp(&b.layer_idx) {
+                    Ordering::Equal => a.track_index.cmp(&b.track_index),
+                    other => other,
+                },
+                other => other,
+            }
+        });
+
+        // Per-layer last placed track index to enforce spacing
+        let mut last_idx_by_layer: Vec<Option<i64>> = vec![None; spacing_by_layer.len()];
+
+        // Iterate candidates; place until we run out of pins
+        for c in candidates.into_iter() {
+            if placed_count >= pins.len() {
+                break;
+            }
+
+            // spacing check (per layer)
+            if let (Some(prev), Some(min_sp)) = (
+                last_idx_by_layer[c.layer_idx],
+                spacing_by_layer[c.layer_idx],
+            ) {
+                let current_rel = c.track_index as i64;
+                if current_rel - prev < min_sp {
+                    continue;
+                }
+            }
+
+            // Identify layer name by priority index
+            let (layer_name, _) = layers
+                .get_index(c.layer_idx)
+                .expect("layer index out of bounds");
+
+            // Check if
+            let layer_shapes = layers.get(layer_name).unwrap();
+            if self
+                .check_pin_placement_on_edge_index_with_polygon(
+                    edge_index,
+                    layer_name,
+                    c.track_index,
+                    Some(&layer_shapes.0),
+                    layer_shapes.1.as_ref(),
+                )
+                .is_err()
+            {
+                continue;
+            }
+
+            let (port_name, bit) = (
+                pins[placed_count].0.as_ref().to_string(),
+                pins[placed_count].1,
+            );
+
+            self.place_pin_on_edge_index(
+                port_name,
+                bit,
+                edge_index,
+                layer_name.as_str(),
+                c.track_index,
+            );
+
+            last_idx_by_layer[c.layer_idx] = Some(c.track_index as i64);
+            placed_count += 1;
+        }
+
+        if placed_count == pins.len() {
+            Ok(())
+        } else {
+            Err(BatchPinPlacementError::RanOutOfLayers {
+                requested: pins.len(),
+                placed: placed_count,
+            })
+        }
+    }
+
+    /// Find the largest uniform spacing that still allows placing all pins,
+    /// then place them. Returns the chosen spacing (in edge-parallel
+    /// coordinate units).
+    pub fn spread_pins_on_edge_index_with_polygons(
+        &self,
+        pins: &[(impl AsRef<str>, usize)],
+        edge_index: usize,
+        layers: IndexMap<String, (Polygon, Option<Polygon>)>,
+        position_range: Range,
+    ) -> Result<(), BatchPinPlacementError> {
+        let search_span = match (position_range.min, position_range.max) {
+            (Some(a), Some(b)) => (b - a).max(0),
+            _ => {
+                // For open-ended ranges, pick a conservative span based on edge range
+                let edge = self.get_edge(edge_index).unwrap();
+                let er = edge.get_coord_range().unwrap();
+                let a = position_range.min.unwrap_or(0);
+                let b = position_range
+                    .max
+                    .unwrap_or(er.max.unwrap() - er.min.unwrap());
+                (b - a).max(0)
+            }
+        };
+
+        let spacing_works = |spacing: i64| -> bool {
+            let sim = self.clone_for_pin_placement();
+            sim.place_pins_on_edge_index_with_polygons(
+                pins,
+                edge_index,
+                layers.clone(),
+                Range {
+                    min: position_range.min,
+                    max: position_range.max,
+                },
+                Some(spacing.max(0)),
+            )
+            .is_ok()
+        };
+
+        // Binary search for maximum spacing in [0, search_span]
+        // Structured such that at any give iteration, "lo" is a
+        // tested spacing that works, but "hi" has not been tested.
+        // The exception is lo=0, which ends up being tested at
+        // the end if no larger spacings work. If lo=0 doesn't work
+        // either, then no spacings will work so the code panics.
+        let mut lo: i64 = 0;
+        let mut hi: i64 = search_span;
+        while lo < hi {
+            // if hi=lo+1, mid will be "hi", i.e. the untested spacing
+            let mid = (lo + hi + 1) / 2;
+            if spacing_works(mid) {
+                lo = mid; // search upper half
+            } else {
+                hi = mid - 1; // search lower half
+            }
+        }
+        let best = lo;
+
+        // Place for real using the best spacing
+        self.place_pins_on_edge_index_with_polygons(
+            pins,
+            edge_index,
+            layers,
+            position_range,
+            Some(best),
+        )?;
+        Ok(())
+    }
+
+    /// Convenience wrapper building layer shapes from default track
+    /// definitions.
+    pub fn spread_pins_on_edge_index<L, S>(
+        &self,
+        pins: &[(impl AsRef<str>, usize)],
+        edge_index: usize,
+        layers: L,
+        position_range: Range,
+    ) -> Result<(), BatchPinPlacementError>
+    where
+        L: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.spread_pins_on_edge_index_with_polygons(
+            pins,
+            edge_index,
+            self.get_default_layer_shapes(layers),
+            position_range,
+        )
+    }
+
+    fn get_default_layer_shapes<L, S>(
+        &self,
+        layers: L,
+    ) -> IndexMap<String, (Polygon, Option<Polygon>)>
+    where
+        L: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut layers_map: IndexMap<String, (Polygon, Option<Polygon>)> = IndexMap::new();
+        for l in layers.into_iter() {
+            let name = l.as_ref();
+            if let Some(track) = self.get_track(name) {
+                if let Some(pin_shape) = track.pin_shape.clone() {
+                    layers_map.insert(name.to_string(), (pin_shape, track.keepout_shape.clone()));
+                }
+            }
+        }
+        layers_map
+    }
+}
+
+macro_rules! place_port_slice_on_named_edge {
+    ($fn_name:ident, $const_name:path) => {
+        paste::paste! {
+            #[doc = concat!(
+                "Places this single-bit slice on the ",
+                stringify!($fn_name),
+                " edge using the default track definition."
+            )]
+            pub fn [<place_on_ $fn_name _edge>](&self, layer: impl AsRef<str>, track_index: usize) {
+                let (port_name, bit) = self.get_port_name_and_bit();
+                self.get_mod_def().[<place_pin_on_ $fn_name _edge>](port_name, bit, layer, track_index);
+            }
+        }
+    };
+}
+
+impl PortSlice {
+    fn get_port_name_and_bit(&self) -> (String, usize) {
         self.check_validity();
         assert!(
             self.width() == 1,
@@ -27,34 +824,58 @@ impl PortSlice {
 
         let port_name = self.port.get_port_name();
         let bit = self.lsb; // since width()==1
+        (port_name, bit)
+    }
 
-        // Validate port exists and bit in range
-        let core_borrow = self.get_mod_def_core();
-        let mut core = core_borrow.borrow_mut();
-        let io = core.ports.get(&port_name).unwrap_or_else(|| {
-            panic!(
-                "Port {}.{} does not exist (adding physical pin)",
-                core.name, port_name
-            )
-        });
-        let width = io.width();
-        if bit >= width {
-            panic!(
-                "Bit {} out of range for port {}.{} with width {}",
-                bit, core.name, port_name, width
-            );
-        }
+    /// Define a physical pin for this single-bit PortSlice, with an arbitrary
+    /// polygon shape relative to `position` on the given `layer`.
+    pub fn place(&self, layer: impl AsRef<str>, position: Coordinate, polygon: Polygon) {
+        let (port_name, bit) = self.get_port_name_and_bit();
+        self.get_mod_def()
+            .place_pin(port_name, bit, layer, position, polygon);
+    }
 
-        // Ensure vector of appropriate width exists on first use
-        let pins_for_port = match core.physical_pins.entry(port_name.to_string()) {
-            Entry::Occupied(e) => e.into_mut(),
-            Entry::Vacant(v) => v.insert(vec![None; width]),
-        };
+    for_each_edge_direction!(place_port_slice_on_named_edge);
+    for_each_edge_direction!(spread_port_slice_pins_on_named_edge);
 
-        pins_for_port[bit] = Some(PhysicalPin {
-            layer: layer.as_ref().to_string(),
-            position,
-            polygon,
-        });
+    /// Define a physical pin for this single-bit `PortSlice` on a specific edge
+    /// by index, using the default pin/keepout shapes from the layer's
+    /// track definition.
+    pub fn place_on_edge_index(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+    ) {
+        let (port_name, bit) = self.get_port_name_and_bit();
+        self.get_mod_def()
+            .place_pin_on_edge_index(port_name, bit, edge_index, layer, track_index);
+    }
+
+    /// Define a physical pin for this single-bit `PortSlice` on a specific edge
+    /// by index, using the provided pin/keepout polygons (relative to the
+    /// track origin). Panics with a descriptive message if the placement is
+    /// not allowed.
+    pub fn place_on_edge_index_with_polygon(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+        pin_polygon: Option<&Polygon>,
+        keepout_polygon: Option<&Polygon>,
+    ) {
+        let (port_name, bit) = self.get_port_name_and_bit();
+        self.get_mod_def().place_pin_on_edge_index_with_polygon(
+            port_name,
+            bit,
+            edge_index,
+            layer,
+            track_index,
+            pin_polygon,
+            keepout_polygon,
+        );
     }
 }
+
+// Generate Port edge helpers
+for_each_edge_direction!(spread_port_pins_on_named_edge);

--- a/src/mod_def/shape.rs
+++ b/src/mod_def/shape.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::mod_def::ModDef;
+
+impl ModDef {
+    /// Returns `true` when the module shape is a four-vertex rectangle. This
+    /// helper assumes the shape has already been validated as rectilinear.
+    pub fn shape_is_rectangular(&self) -> bool {
+        let core = self.core.borrow();
+        if let Some(shape) = &core.shape {
+            // Shape is already checked to be rectilinear when it is
+            // added to a ModDef, so we only need to check the number
+            // of vertices here.
+            shape.num_vertices() == 4
+        } else {
+            panic!("Shape is not defined");
+        }
+    }
+}

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -42,6 +42,8 @@ impl ModDef {
                 layer: self.core.borrow().layer.clone(),
                 inst_placements: IndexMap::new(),
                 physical_pins: IndexMap::new(),
+                track_definitions: None,
+                track_occupancies: None,
             })),
         }
     }

--- a/src/mod_def/tracks.rs
+++ b/src/mod_def/tracks.rs
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::mod_def::dtypes::{EdgeOrientation, Polygon, Range};
+use indexmap::IndexMap;
+
+use fixedbitset::FixedBitSet;
+
+use crate::mod_def::{
+    BOTTOM_EDGE_INDEX, EAST_EDGE_INDEX, LEFT_EDGE_INDEX, NORTH_EDGE_INDEX, RIGHT_EDGE_INDEX,
+    SOUTH_EDGE_INDEX, TOP_EDGE_INDEX, WEST_EDGE_INDEX,
+};
+use crate::{Coordinate, Mat3, ModDef, Orientation};
+
+use std::fmt;
+
+/// Error type describing why a pin or keepout cannot be placed on a track.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinPlacementError {
+    /// The module shape or track occupancies were not initialized.
+    NotInitialized(&'static str),
+    /// The requested edge index is out of bounds for the current shape.
+    EdgeOutOfBounds { edge_index: usize, num_edges: usize },
+    /// The requested routing layer is not present on this edge.
+    LayerUnavailable { layer: String },
+    /// The requested pin span is out of bounds for the available tracks on this
+    /// edge.
+    OutOfBounds {
+        min_index: i64,
+        max_index: i64,
+        num_tracks: usize,
+    },
+    /// The requested pin overlaps an existing pin.
+    OverlapsExistingPin { min_index: i64, max_index: i64 },
+    /// The requested pin overlaps a keepout region.
+    OverlapsKeepout { min_index: i64, max_index: i64 },
+}
+
+impl fmt::Display for PinPlacementError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PinPlacementError::NotInitialized(what) => {
+                write!(
+                    f,
+                    "{} not initialized; call set_shape and set_track_definitions first",
+                    what
+                )
+            }
+            PinPlacementError::EdgeOutOfBounds {
+                edge_index,
+                num_edges,
+            } => write!(
+                f,
+                "edge index {} is out of bounds ({} edges available)",
+                edge_index, num_edges
+            ),
+            PinPlacementError::LayerUnavailable { layer } => {
+                write!(f, "layer '{}' has no tracks on this edge", layer)
+            }
+            PinPlacementError::OutOfBounds {
+                min_index,
+                max_index,
+                num_tracks,
+            } => write!(
+                f,
+                "requested track span [{}..={}] is outside available range [0..={}]",
+                min_index,
+                max_index,
+                num_tracks.saturating_sub(1)
+            ),
+            PinPlacementError::OverlapsExistingPin {
+                min_index,
+                max_index,
+            } => write!(
+                f,
+                "requested track span [{}..={}] overlaps an existing pin",
+                min_index, max_index
+            ),
+            PinPlacementError::OverlapsKeepout {
+                min_index,
+                max_index,
+            } => write!(
+                f,
+                "requested track span [{}..={}] overlaps a keepout region",
+                min_index, max_index
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PinPlacementError {}
+
+/// Orientation of routing tracks.
+#[derive(Clone, PartialEq, Eq)]
+pub enum TrackOrientation {
+    Horizontal,
+    Vertical,
+}
+
+impl TrackOrientation {
+    /// Returns `true` when this track orientation can legally place pins on an
+    /// edge with the supplied [`EdgeOrientation`]. Horizontal tracks may only
+    /// service north/south edges, while vertical tracks may only service
+    /// east/west edges.
+    pub fn is_compatible_with_edge_orientation(&self, edge_orientation: &EdgeOrientation) -> bool {
+        matches!(
+            (self, edge_orientation),
+            (
+                TrackOrientation::Horizontal,
+                EdgeOrientation::North | EdgeOrientation::South
+            ) | (
+                TrackOrientation::Vertical,
+                EdgeOrientation::East | EdgeOrientation::West
+            )
+        )
+    }
+}
+
+/// Definition of a routing track family on a named layer.
+#[derive(Clone)]
+pub struct TrackDefinition {
+    pub(crate) name: String,
+    pub(crate) offset: i64,
+    pub(crate) period: i64,
+    pub(crate) orientation: TrackOrientation,
+    pub(crate) pin_shape: Option<Polygon>,
+    pub(crate) keepout_shape: Option<Polygon>,
+}
+
+impl TrackDefinition {
+    /// Create a new [`TrackDefinition`].
+    /// - `name`: routing layer name (e.g. "M1")
+    /// - `offset`: first track coordinate relative to the edge origin
+    /// - `period`: spacing between adjacent tracks
+    /// - `orientation`: horizontal or vertical
+    /// - `pin_shape`: optional pin polygon relative to the track origin
+    /// - `keepout_shape`: optional keepout polygon relative to the track origin
+    pub fn new(
+        name: impl AsRef<str>,
+        offset: i64,
+        period: i64,
+        orientation: TrackOrientation,
+        pin_shape: Option<Polygon>,
+        keepout_shape: Option<Polygon>,
+    ) -> Self {
+        TrackDefinition {
+            name: name.as_ref().to_string(),
+            offset,
+            period,
+            orientation,
+            pin_shape,
+            keepout_shape,
+        }
+    }
+
+    /// Convert a coordinate range to track indices such that converting the
+    /// quantized range back to coordinates will not exceed the original
+    /// range.
+    pub fn convert_coord_range_to_index_range(&self, range: &Range) -> Range {
+        debug_assert!(self.period > 0);
+
+        Range {
+            min: range
+                .min
+                .map(|min| (min - self.offset + self.period - 1) / self.period),
+            max: range.max.map(|max| (max - self.offset) / self.period),
+        }
+    }
+
+    /// Convert a track index range to a coordinate range.
+    pub fn convert_index_range_to_coord_range(&self, range: &Range) -> Range {
+        Range {
+            min: range.min.map(|min| self.offset + (min * self.period)),
+            max: range.max.map(|max| self.offset + (max * self.period)),
+        }
+    }
+
+    /// Convert a track index to a coordinate.
+    pub fn index_to_position(&self, index: i64) -> i64 {
+        self.offset + (index * self.period)
+    }
+}
+
+/// Collection of track definitions keyed by layer name.
+#[derive(Clone)]
+pub struct TrackDefinitions(pub(crate) IndexMap<String, TrackDefinition>);
+
+impl TrackDefinitions {
+    /// Creates an empty collection of track definitions.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a track definition.
+    pub fn add_track(&mut self, track: TrackDefinition) {
+        self.0.insert(track.name.clone(), track);
+    }
+
+    /// Get a track definition by layer name.
+    pub fn get_track(&self, name: &str) -> Option<&TrackDefinition> {
+        self.0.get(name)
+    }
+}
+
+impl Default for TrackDefinitions {
+    fn default() -> Self {
+        TrackDefinitions(IndexMap::new())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TrackOccupancy {
+    pub(crate) pin_occupancies: FixedBitSet,
+    pub(crate) keepout_occupancies: FixedBitSet,
+}
+
+impl TrackOccupancy {
+    /// Creates a new occupancy bitmap capable of tracking `num_tracks` track
+    /// slots for both pins and keepouts.
+    pub fn new(num_tracks: usize) -> Self {
+        TrackOccupancy {
+            pin_occupancies: FixedBitSet::with_capacity(num_tracks),
+            keepout_occupancies: FixedBitSet::with_capacity(num_tracks),
+        }
+    }
+
+    /// Validate that a pin can be placed on tracks in the half-open span
+    /// [min_index, max_index].
+    pub fn check_place_pin(&self, min_index: i64, max_index: i64) -> Result<(), PinPlacementError> {
+        if min_index < 0 || max_index < 0 || (max_index as usize) >= self.pin_occupancies.len() {
+            return Err(PinPlacementError::OutOfBounds {
+                min_index,
+                max_index,
+                num_tracks: self.pin_occupancies.len(),
+            });
+        }
+        let min_index_usize = min_index as usize;
+        let max_index_usize = max_index as usize;
+        let range = min_index_usize..(max_index_usize + 1);
+        if self.pin_occupancies.contains_any_in_range(range.clone()) {
+            return Err(PinPlacementError::OverlapsExistingPin {
+                min_index,
+                max_index,
+            });
+        }
+        if self.keepout_occupancies.contains_any_in_range(range) {
+            return Err(PinPlacementError::OverlapsKeepout {
+                min_index,
+                max_index,
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate that a keepout can be placed. Keepouts are clipped to the edge
+    /// span.
+    pub fn check_place_keepout(
+        &self,
+        min_index: i64,
+        max_index: i64,
+    ) -> Result<(), PinPlacementError> {
+        if max_index < 0 {
+            // Entirely before the first track after clipping; trivially OK.
+            return Ok(());
+        }
+        let clipped_min_index = min_index.max(0) as usize;
+        let clipped_max_index = max_index.min((self.pin_occupancies.len() as i64) - 1) as usize;
+        let range = clipped_min_index..(clipped_max_index + 1);
+        if self.pin_occupancies.contains_any_in_range(range) {
+            return Err(PinPlacementError::OverlapsExistingPin {
+                min_index,
+                max_index,
+            });
+        }
+        Ok(())
+    }
+
+    /// Marks the inclusive range `[min_index, max_index]` as occupied by a
+    /// pin, preventing future placements from overlapping.
+    pub fn mark_pin(&mut self, min_index: i64, max_index: i64) {
+        let min_index = min_index as usize;
+        let max_index = max_index as usize;
+        self.pin_occupancies
+            .set_range(min_index..(max_index + 1), true);
+    }
+
+    /// Marks the inclusive range `[min_index, max_index]` as a keepout region,
+    /// clipping indices that fall outside the known edge span.
+    pub fn mark_keepout(&mut self, min_index: i64, max_index: i64) {
+        let max_index = if max_index < 0 {
+            return;
+        } else {
+            max_index as usize
+        };
+        let clipped_max_index = max_index.min(self.pin_occupancies.len() - 1);
+        let clipped_min_index = if min_index < 0 { 0 } else { min_index as usize };
+        self.keepout_occupancies
+            .set_range(clipped_min_index..(clipped_max_index + 1), true);
+    }
+
+    /// Convenience helper that records both the pin and keepout ranges and
+    /// ensures the pin body itself is not treated as a keepout afterwards.
+    pub fn place_pin_and_keepout(
+        &mut self,
+        pin_min_index: i64,
+        pin_max_index: i64,
+        keepout_min_index: i64,
+        keepout_max_index: i64,
+    ) {
+        self.mark_pin(pin_min_index, pin_max_index);
+        self.mark_keepout(keepout_min_index, keepout_max_index);
+
+        let pin_range = (pin_min_index as usize)..((pin_max_index as usize) + 1);
+        self.keepout_occupancies.remove_range(pin_range);
+    }
+
+    /// Returns a bitmap of tracks that are currently free between
+    /// `min_index` and `max_index`, inclusive.
+    pub fn get_available_indices_in_range(
+        &self,
+        min_index: usize,
+        max_index: usize,
+    ) -> FixedBitSet {
+        let mut retval = self.pin_occupancies.clone();
+        retval.union_with(&self.keepout_occupancies);
+        if min_index > 0 {
+            retval.insert_range(..min_index);
+        }
+        if max_index < (retval.len() - 1) {
+            retval.insert_range((max_index + 1)..);
+        }
+        retval.toggle_range(..);
+        retval
+    }
+}
+
+pub(crate) struct TrackOccupancies(pub(crate) Vec<IndexMap<String, TrackOccupancy>>);
+
+impl TrackOccupancies {
+    /// Allocates per-edge occupancy maps for the provided number of edges.
+    pub fn new(num_edges: usize) -> Self {
+        let mut occupancies = Vec::with_capacity(num_edges);
+        for _ in 0..num_edges {
+            occupancies.push(IndexMap::new());
+        }
+        TrackOccupancies(occupancies)
+    }
+
+    /// Returns the immutable occupancy record for `edge_index` and `layer`, if
+    /// one has been initialized.
+    pub fn get_occupancy(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+    ) -> Option<&TrackOccupancy> {
+        self.0
+            .get(edge_index)
+            .and_then(|edge_map| edge_map.get(layer.as_ref()))
+    }
+
+    /// Returns the mutable occupancy record for `edge_index` and `layer`, if
+    /// one has been initialized.
+    pub fn get_occupancy_mut(
+        &mut self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+    ) -> Option<&mut TrackOccupancy> {
+        self.0
+            .get_mut(edge_index)
+            .and_then(|edge_map| edge_map.get_mut(layer.as_ref()))
+    }
+}
+
+macro_rules! can_place_pin_on_edge {
+    ($fn_name:ident, $const_name:ident) => {
+        #[doc = concat!(
+                                            "Returns `true` when a pin can be placed on the ",
+                                            stringify!($fn_name),
+                                            " edge for the requested layer and track index."
+                                        )]
+        pub fn $fn_name(&self, layer: impl AsRef<str>, track_index: usize) -> bool {
+            self.can_place_pin_on_edge_index($const_name, layer, track_index)
+        }
+    };
+}
+
+impl ModDef {
+    /// Convert a track index on a given edge and layer into an absolute
+    /// position and transform that orients a pin polygon to the edge
+    /// orientation.
+    pub fn track_index_to_position_and_transform(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+    ) -> (Coordinate, Mat3) {
+        let layer_ref = layer.as_ref();
+        let track = self
+            .get_track(layer_ref)
+            .unwrap_or_else(|| panic!("Unknown track layer '{}'", layer_ref));
+        let edge = self
+            .get_edge(edge_index)
+            .unwrap_or_else(|| panic!("Edge index {} is out of bounds", edge_index));
+        let position = edge.get_coordinate_on_edge(&track, track_index);
+        let transform = match edge.orientation() {
+            Some(EdgeOrientation::North) => Mat3::identity(),
+            Some(EdgeOrientation::South) => Mat3::from_orientation(Orientation::R180),
+            Some(EdgeOrientation::East) => Mat3::from_orientation(Orientation::R270),
+            Some(EdgeOrientation::West) => Mat3::from_orientation(Orientation::R90),
+            None => panic!("Edge is not axis-aligned; only rectilinear edges are supported"),
+        };
+        (position, transform)
+    }
+
+    pub(crate) fn track_range_for_polygon(
+        &self,
+        layer: impl AsRef<str>,
+        track_index: usize,
+        polygon: &Polygon,
+    ) -> (i64, i64) {
+        let track = self.get_track(layer.as_ref()).unwrap();
+        let bbox = polygon.bbox();
+        let (min_delta, max_delta) = match track.orientation {
+            TrackOrientation::Horizontal => (bbox.min_y, bbox.max_y),
+            TrackOrientation::Vertical => (bbox.min_x, bbox.max_x),
+        };
+        let tracks_below = min_delta / track.period;
+        let tracks_above = max_delta / track.period;
+        (
+            (track_index as i64) + tracks_below,
+            (track_index as i64) + tracks_above,
+        )
+    }
+
+    can_place_pin_on_edge!(can_place_pin_on_west_edge, WEST_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_left_edge, LEFT_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_north_edge, NORTH_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_top_edge, TOP_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_east_edge, EAST_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_right_edge, RIGHT_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_south_edge, SOUTH_EDGE_INDEX);
+    can_place_pin_on_edge!(can_place_pin_on_bottom_edge, BOTTOM_EDGE_INDEX);
+
+    /// Boolean convenience wrapper around
+    /// [`ModDef::check_pin_placement_on_edge_index`].
+    pub fn can_place_pin_on_edge_index(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+    ) -> bool {
+        let track = self.get_track(layer.as_ref()).unwrap();
+        self.check_pin_placement_on_edge_index_with_polygon(
+            edge_index,
+            layer,
+            track_index,
+            track.pin_shape.as_ref(),
+            track.keepout_shape.as_ref(),
+        )
+        .is_ok()
+    }
+
+    /// Validate that a pin/keepout combination can be placed using the default
+    /// shapes for the layer, returning `Ok(())` on success or a detailed
+    /// [`PinPlacementError`] on failure.
+    pub fn check_pin_placement_on_edge_index(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+    ) -> Result<(), PinPlacementError> {
+        let track = self.get_track(layer.as_ref()).unwrap();
+        self.check_pin_placement_on_edge_index_with_polygon(
+            edge_index,
+            layer,
+            track_index,
+            track.pin_shape.as_ref(),
+            track.keepout_shape.as_ref(),
+        )
+    }
+
+    /// Validate that a pin/keepout combination can be placed using the provided
+    /// polygons, returning `Ok(())` on success or a detailed
+    /// [`PinPlacementError`] on failure.
+    pub fn check_pin_placement_on_edge_index_with_polygon(
+        &self,
+        edge_index: usize,
+        layer: impl AsRef<str>,
+        track_index: usize,
+        pin_polygon: Option<&Polygon>,
+        keepout_polygon: Option<&Polygon>,
+    ) -> Result<(), PinPlacementError> {
+        let core = self.core.borrow();
+        let occupancies = core
+            .track_occupancies
+            .as_ref()
+            .ok_or(PinPlacementError::NotInitialized("Track occupancies"))?;
+        let num_edges = occupancies.0.len();
+        let edge_map = occupancies
+            .0
+            .get(edge_index)
+            .ok_or(PinPlacementError::EdgeOutOfBounds {
+                edge_index,
+                num_edges,
+            })?;
+        let layer_ref = layer.as_ref();
+        let occupancy =
+            edge_map
+                .get(layer_ref)
+                .ok_or_else(|| PinPlacementError::LayerUnavailable {
+                    layer: layer_ref.to_string(),
+                })?;
+
+        if let Some(pin_polygon) = pin_polygon {
+            let (min_track_index, max_track_index) =
+                self.track_range_for_polygon(layer_ref, track_index, pin_polygon);
+            occupancy.check_place_pin(min_track_index, max_track_index)?;
+        }
+
+        if let Some(keepout_polygon) = keepout_polygon {
+            let (min_track_index, max_track_index) =
+                self.track_range_for_polygon(layer_ref, track_index, keepout_polygon);
+            occupancy.check_place_keepout(min_track_index, max_track_index)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/port.rs
+++ b/src/port.rs
@@ -159,6 +159,16 @@ impl Port {
     pub fn subdivide(&self, n: usize) -> Vec<PortSlice> {
         self.to_port_slice().subdivide(n)
     }
+
+    /// Returns an ordered list of `(port name, bit index)` pairs covering every
+    /// bit of this port.
+    pub fn to_bits(&self) -> Vec<(&str, usize)> {
+        let mut bits = Vec::new();
+        for i in 0..self.io().width() {
+            bits.push((self.name(), i));
+        }
+        bits
+    }
 }
 
 impl ConvertibleToPortSlice for Port {

--- a/src/port_slice.rs
+++ b/src/port_slice.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::{ModDefCore, Port};
+use crate::{ModDef, ModDefCore, Port};
 
 mod connect;
 mod export;
@@ -81,6 +81,12 @@ impl PortSlice {
         }
     }
 
+    pub(crate) fn get_mod_def(&self) -> ModDef {
+        ModDef {
+            core: self.get_mod_def_core(),
+        }
+    }
+
     pub(crate) fn check_validity(&self) {
         if self.msb >= self.port.io().width() {
             panic!(
@@ -102,6 +108,14 @@ impl PortSlice {
             Port::ModInst { inst_name, .. } => Some(inst_name.clone()),
             _ => None,
         }
+    }
+
+    /// Returns `(port name, bit index)` pairs describing every bit covered by
+    /// this slice, ordered from LSB to MSB.
+    pub fn to_bits(&self) -> Vec<(&str, usize)> {
+        (self.lsb..=self.msb)
+            .map(|i| (self.port.name(), i))
+            .collect()
     }
 }
 

--- a/tests/emit_lefdef.rs
+++ b/tests/emit_lefdef.rs
@@ -14,6 +14,25 @@ fn target_out(sub: &str) -> PathBuf {
 }
 
 #[test]
+fn emit_lef_for_single_module() {
+    let block = ModDef::new("block");
+    block.set_width_height(100, 200);
+    block.set_layer("OUTLINE");
+
+    let opts = LefDefOptions::default();
+    let lef = block.emit_lef(&opts);
+    assert!(lef.contains("MACRO block"));
+    assert!(lef.contains("SIZE 100 BY 200 ;"));
+
+    let lef_path = target_out("single_block.lef");
+    block
+        .emit_lef_to_file(&lef_path, &opts)
+        .expect("emit single block LEF");
+    let lef_disk = fs::read_to_string(&lef_path).unwrap();
+    assert_eq!(lef, lef_disk);
+}
+
+#[test]
 fn emit_lef_and_def_strings_and_files() {
     let top = ModDef::new("top");
     let block = ModDef::new("block");

--- a/tests/lef_pins.rs
+++ b/tests/lef_pins.rs
@@ -21,12 +21,12 @@ fn generate_lef_with_pins_and_positions() {
     block
         .get_port("a")
         .bit(0)
-        .define_physical_pin("M1", (0, 15).into(), pin.clone());
+        .place("M1", (0, 15).into(), pin.clone());
     block
         .get_port("a")
         .bit(1)
-        .define_physical_pin("M1", (0, 35).into(), pin.clone());
-    block.get_port("b").bit(0).define_physical_pin(
+        .place("M1", (0, 35).into(), pin.clone());
+    block.get_port("b").bit(0).place(
         "M2",
         (100, 25).into(),
         pin.apply_transform(&Mat3::from_orientation(Orientation::MY)),
@@ -45,23 +45,23 @@ fn generate_lef_with_pins_and_positions() {
     // Macro and outline
     assert!(lef.contains("MACRO block"));
     assert!(lef.contains("LAYER OUTLINE"));
-    assert!(lef.contains("POLYGON ( 0 0 100 0 100 50 0 50 ) ;"));
+    assert!(lef.contains("POLYGON ( 0 0 0 50 100 50 100 0 ) ;"));
 
     // a[0]
     assert!(lef.contains("PIN a[0]"));
     assert!(lef.contains("DIRECTION INPUT"));
     assert!(lef.contains("LAYER M1"));
-    assert!(lef.contains("POLYGON ( 0 10 20 10 20 20 0 20 ) ;"));
+    assert!(lef.contains("POLYGON ( 0 10 0 20 20 20 20 10 ) ;"));
 
     // a[1]
     assert!(lef.contains("PIN a[1]"));
     assert!(lef.contains("DIRECTION INPUT"));
     assert!(lef.contains("LAYER M1"));
-    assert!(lef.contains("POLYGON ( 0 30 20 30 20 40 0 40 ) ;"));
+    assert!(lef.contains("POLYGON ( 0 30 0 40 20 40 20 30 ) ;"));
 
     // b[0]
     assert!(lef.contains("PIN b[0]"));
     assert!(lef.contains("DIRECTION OUTPUT"));
     assert!(lef.contains("LAYER M2"));
-    assert!(lef.contains("POLYGON ( 100 20 80 20 80 30 100 30 ) ;"));
+    assert!(lef.contains("POLYGON ( 100 20 100 30 80 30 80 20 ) ;"));
 }

--- a/tests/placement.rs
+++ b/tests/placement.rs
@@ -27,9 +27,9 @@ fn placement_basic() {
         abs_shape,
         Polygon::new(vec![
             (10, 20).into(),
-            (110, 20).into(),
-            (110, 220).into(),
             (10, 220).into(),
+            (110, 220).into(),
+            (110, 20).into(),
         ])
     );
 }
@@ -61,9 +61,9 @@ fn placement_skip_level() {
         abs_shape,
         Polygon::new(vec![
             (10, 20).into(),
-            (110, 20).into(),
-            (110, 220).into(),
             (10, 220).into(),
+            (110, 220).into(),
+            (110, 20).into(),
         ])
     );
 }
@@ -97,9 +97,9 @@ fn placement_relative_basic() {
         abs_shape,
         Polygon::new(vec![
             (44, 112).into(),
-            (44, 12).into(),
-            (-156, 12).into(),
             (-156, 112).into(),
+            (-156, 12).into(),
+            (44, 12).into(),
         ])
     );
 }
@@ -144,9 +144,9 @@ fn placement_relative_to_parent() {
         b_placed.get("top/i_inst_0/b_inst_0"),
         Some(&Polygon::new(vec![
             (100, 200).into(),
-            (500, 200).into(),
-            (500, 500).into(),
             (100, 500).into(),
+            (500, 500).into(),
+            (500, 200).into(),
         ]))
     );
 
@@ -154,9 +154,9 @@ fn placement_relative_to_parent() {
         b_placed.get("top/i_inst_1/b_inst_0"),
         Some(&Polygon::new(vec![
             (100, -200).into(),
-            (500, -200).into(),
-            (500, -500).into(),
             (100, -500).into(),
+            (500, -500).into(),
+            (500, -200).into(),
         ]))
     );
 
@@ -164,9 +164,9 @@ fn placement_relative_to_parent() {
         b_placed.get("top/i_inst_2/b_inst_0"),
         Some(&Polygon::new(vec![
             (-100, -200).into(),
-            (-500, -200).into(),
-            (-500, -500).into(),
             (-100, -500).into(),
+            (-500, -500).into(),
+            (-500, -200).into(),
         ]))
     );
 
@@ -174,9 +174,9 @@ fn placement_relative_to_parent() {
         b_placed.get("top/i_inst_3/b_inst_0"),
         Some(&Polygon::new(vec![
             (-100, 200).into(),
-            (-500, 200).into(),
-            (-500, 500).into(),
             (-100, 500).into(),
+            (-500, 500).into(),
+            (-500, 200).into(),
         ]))
     );
 }

--- a/tests/spdx_test.rs
+++ b/tests/spdx_test.rs
@@ -64,21 +64,13 @@ fn find_missing_spdx_files(root: &Path) -> Vec<PathBuf> {
                 // Exclude directories that should not be checked
                 if entry.file_name() != "target"
                     && entry.file_name() != ".git"
-                    && entry.file_name() != "xlsynth_tools"
+                    && !(entry.file_name() == "output"
+                        && entry.path().parent().and_then(|p| p.file_name())
+                            == Some("examples".as_ref()))
                 {
                     println!("Adding to directory worklist: {path:?}");
                     dir_worklist.push(path.clone());
                 }
-                continue;
-            }
-
-            // For golden comparison files (i.e. ones we compare to literally for code
-            // generation facilities) we don't require SPDX identifiers.
-            if path.as_os_str().to_str().unwrap().ends_with(".golden.sv") {
-                continue;
-            }
-
-            if path.file_name().unwrap().to_str().unwrap() == "estimator_model.proto" {
                 continue;
             }
 


### PR DESCRIPTION
Provides features for spreading pins on edges and across tracks; see example usage in `examples/pin_range_example.rs`. Sample output is shown below, illustrating how pins can be placed on part or all of an edge using a range specifier. (I put a 1/4 pitch offset between metal layers in this example to make it easier to see all in one image.)

Although not shown in the example code, there are various lower-level features for placing pins and keepouts on specific track indices; these are the features that pin spreading is built on. Pin spreading is currently implemented as a binary search that aims to maximize the minimum distance between placed pins across layers.

This PR isn't about performance, but I did a quick experiment to see where performance stands. Looks like I can assign about 100,000 pins in 5-6s with the current implementation. If need be, there are many ways performance could be improved in future PRs.

<img width="715" height="656" alt="image" src="https://github.com/user-attachments/assets/7470f9fa-2fb5-472f-bbad-b86a2529e2c2" />
