### PR TITLE
Update pin spread algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.66.0"
+version = "0.67.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/examples/pin_range_example.rs
+++ b/examples/pin_range_example.rs
@@ -2,8 +2,8 @@
 
 use std::path::PathBuf;
 use topstitch::{
-    BoundingBox, LefDefOptions, ModDef, Polygon, Range, TrackDefinition, TrackDefinitions,
-    TrackOrientation, IO,
+    BoundingBox, LefDefOptions, ModDef, Polygon, Range, SpreadPinsOptions, TrackDefinition,
+    TrackDefinitions, TrackOrientation, IO,
 };
 
 const NUM_BITS: usize = 5;
@@ -60,11 +60,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let layers = m.get_layers();
 
     // Variety of different mechanisms shown for spreading pins on edges
-    in_left.spread_pins_on_left_edge(&layers, Range::from_min(MODULE_HEIGHT / 2))?;
-    m.spread_pins_on_right_edge(&out_right.to_bits(), &layers, Range::any())?;
-    in_top.spread_pins_on_top_edge(&layers, Range::new(MODULE_WIDTH / 4, 3 * MODULE_WIDTH / 4))?;
-    out_bottom
-        .spread_pins_on_bottom_edge(&layers, Range::new(MODULE_WIDTH / 4, 3 * MODULE_WIDTH / 4))?;
+    in_left.spread_pins_on_left_edge(
+        &layers,
+        SpreadPinsOptions {
+            range: Range::from_min(MODULE_HEIGHT / 2),
+            ..Default::default()
+        },
+    )?;
+    m.spread_pins_on_right_edge(
+        &out_right.to_bits(),
+        &layers,
+        SpreadPinsOptions {
+            ..Default::default()
+        },
+    )?;
+    in_top.spread_pins_on_top_edge(
+        &layers,
+        SpreadPinsOptions {
+            range: Range::new(MODULE_WIDTH / 4, 3 * MODULE_WIDTH / 4),
+            ..Default::default()
+        },
+    )?;
+    out_bottom.spread_pins_on_bottom_edge(
+        &layers,
+        SpreadPinsOptions {
+            range: Range::new(MODULE_WIDTH / 4, 3 * MODULE_WIDTH / 4),
+            ..Default::default()
+        },
+    )?;
 
     // Emit LEF for viewing
     let lef_path = out_dir.join("pin_range_example.lef");

--- a/examples/pinning.rs
+++ b/examples/pinning.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 use topstitch::{
-    BoundingBox, LefDefOptions, ModDef, Orientation, Polygon, Range, TrackDefinition,
+    BoundingBox, LefDefOptions, ModDef, Orientation, Polygon, SpreadPinsOptions, TrackDefinition,
     TrackDefinitions, TrackOrientation, Usage, IO,
 };
 
@@ -38,10 +38,18 @@ fn build_leaf(
 
     // Pin inputs and outputs
     let layers = m.get_layers();
-    m.get_port("in")
-        .spread_pins_on_left_edge(&layers, Range::any())?;
-    m.get_port("out")
-        .spread_pins_on_right_edge(&layers, Range::any())?;
+    m.get_port("in").spread_pins_on_left_edge(
+        &layers,
+        SpreadPinsOptions {
+            ..Default::default()
+        },
+    )?;
+    m.get_port("out").spread_pins_on_right_edge(
+        &layers,
+        SpreadPinsOptions {
+            ..Default::default()
+        },
+    )?;
 
     // Mark as a leaf for LEF/DEF emission
     m.set_usage(Usage::EmitStubAndStop);

--- a/src/lefdef.rs
+++ b/src/lefdef.rs
@@ -146,7 +146,7 @@ pub fn generate_lef(macros: &[LefComponent], opts: &LefDefOptions) -> String {
             s.push_str("    PORT\n");
             s.push_str(&format!("      LAYER {} ;\n", p.shape.layer));
             let poly = p.shape.to_lef_polygon(opts.units_microns);
-            s.push_str(&format!("      {}\n", poly));
+            s.push_str(&format!("      {poly}\n"));
             s.push_str("    END\n");
             s.push_str(&format!("  END {}\n", p.name));
         }
@@ -154,7 +154,7 @@ pub fn generate_lef(macros: &[LefComponent], opts: &LefDefOptions) -> String {
         let poly = m.shape.to_lef_polygon(opts.units_microns);
         s.push_str("  OBS\n");
         s.push_str(&format!("    LAYER {} ;\n", m.shape.layer));
-        s.push_str(&format!("      {}\n", poly));
+        s.push_str(&format!("      {poly}\n"));
         s.push_str("  END\n");
         s.push_str("END ");
         s.push_str(&m.name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,3 +50,4 @@ pub use package::{
 };
 
 pub use mod_def::ParserConfig;
+pub use mod_def::SpreadPinsOptions;

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub use self::pins::SpreadPinsOptions;
+
 use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};

--- a/src/mod_def/dtypes.rs
+++ b/src/mod_def/dtypes.rs
@@ -54,7 +54,7 @@ impl From<(i64, i64)> for Coordinate {
 }
 
 /// Represents an optionally bounded inclusive interval along an edge or track.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Range {
     pub min: Option<i64>,
     pub max: Option<i64>,
@@ -104,17 +104,17 @@ impl Range {
     /// Returns `true` if `value` lies inside the inclusive bounds of this
     /// range.
     pub fn contains(&self, value: i64) -> bool {
-        self.min.map_or(true, |min| value >= min) && self.max.map_or(true, |max| value <= max)
+        self.min.is_none_or(|min| value >= min) && self.max.is_none_or(|max| value <= max)
     }
 
     /// Returns `true` if every value in `self` is also contained within
     /// `other`.
     pub fn is_subset_of(&self, other: &Range) -> bool {
-        self.min.map_or(true, |self_min| {
-            other.min.map_or(true, |other_min| self_min >= other_min)
-        }) && self.max.map_or(true, |self_max| {
-            other.max.map_or(true, |other_max| self_max <= other_max)
-        })
+        self.min
+            .is_none_or(|self_min| other.min.is_none_or(|other_min| self_min >= other_min))
+            && self
+                .max
+                .is_none_or(|self_max| other.max.is_none_or(|other_max| self_max <= other_max))
     }
 
     /// Computes the overlapping portion of two ranges, if any.
@@ -141,9 +141,9 @@ impl Range {
 impl std::fmt::Display for Range {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match (self.min, self.max) {
-            (Some(min), Some(max)) => write!(f, "[{}, {}]", min, max),
-            (Some(min), None) => write!(f, "[{}, ...]", min),
-            (None, Some(max)) => write!(f, "[..., {}]", max),
+            (Some(min), Some(max)) => write!(f, "[{min}, {max}]"),
+            (Some(min), None) => write!(f, "[{min}, ...]"),
+            (None, Some(max)) => write!(f, "[..., {max}]"),
             (None, None) => write!(f, "[...]"),
         }
     }

--- a/src/mod_def/lefdef.rs
+++ b/src/mod_def/lefdef.rs
@@ -67,7 +67,7 @@ impl ModDef {
         let shape = core
             .shape
             .as_ref()
-            .unwrap_or_else(|| panic!("Module '{}' has no shape defined", name));
+            .unwrap_or_else(|| panic!("Module '{name}' has no shape defined"));
         let bbox = shape.bbox();
         assert!(bbox.min_x >= 0, "LEFs do not support negative coordinates");
         assert!(bbox.min_y >= 0, "LEFs do not support negative coordinates");
@@ -77,8 +77,8 @@ impl ModDef {
         for (port_name, pins) in core.physical_pins.iter() {
             let port = core.ports.get(port_name).unwrap_or_else(|| {
                 panic!(
-                    "Physical pin defined for unknown port {}.{}",
-                    core.name, port_name
+                    "Physical pin defined for unknown port {}.{port_name}",
+                    core.name
                 )
             });
             let direction = match port {
@@ -136,10 +136,8 @@ fn placements_to_def_components(
         .iter()
         .map(|(inst_name, p)| {
             let lef_component = lef_components.get(&p.module).unwrap_or_else(|| {
-                panic!(
-                    "No LEF component found for module '{}' (needed for DEF placement)",
-                    p.module
-                )
+                let module = &p.module;
+                panic!("No LEF component found for module '{module}' (needed for DEF placement)")
             });
             let bbox = Polygon::from_width_height(lef_component.width, lef_component.height)
                 .apply_transform(&p.transform)

--- a/src/mod_def/tracks.rs
+++ b/src/mod_def/tracks.rs
@@ -41,8 +41,7 @@ impl fmt::Display for PinPlacementError {
             PinPlacementError::NotInitialized(what) => {
                 write!(
                     f,
-                    "{} not initialized; call set_shape and set_track_definitions first",
-                    what
+                    "{what} not initialized; call set_shape and set_track_definitions first"
                 )
             }
             PinPlacementError::EdgeOutOfBounds {
@@ -50,11 +49,10 @@ impl fmt::Display for PinPlacementError {
                 num_edges,
             } => write!(
                 f,
-                "edge index {} is out of bounds ({} edges available)",
-                edge_index, num_edges
+                "edge index {edge_index} is out of bounds ({num_edges} edges available)"
             ),
             PinPlacementError::LayerUnavailable { layer } => {
-                write!(f, "layer '{}' has no tracks on this edge", layer)
+                write!(f, "layer '{layer}' has no tracks on this edge")
             }
             PinPlacementError::OutOfBounds {
                 min_index,
@@ -62,9 +60,7 @@ impl fmt::Display for PinPlacementError {
                 num_tracks,
             } => write!(
                 f,
-                "requested track span [{}..={}] is outside available range [0..={}]",
-                min_index,
-                max_index,
+                "requested track span [{min_index}..={max_index}] is outside available range [0..={}]",
                 num_tracks.saturating_sub(1)
             ),
             PinPlacementError::OverlapsExistingPin {
@@ -72,16 +68,14 @@ impl fmt::Display for PinPlacementError {
                 max_index,
             } => write!(
                 f,
-                "requested track span [{}..={}] overlaps an existing pin",
-                min_index, max_index
+                "requested track span [{min_index}..={max_index}] overlaps an existing pin"
             ),
             PinPlacementError::OverlapsKeepout {
                 min_index,
                 max_index,
             } => write!(
                 f,
-                "requested track span [{}..={}] overlaps a keepout region",
-                min_index, max_index
+                "requested track span [{min_index}..={max_index}] overlaps a keepout region"
             ),
         }
     }
@@ -396,10 +390,10 @@ impl ModDef {
         let layer_ref = layer.as_ref();
         let track = self
             .get_track(layer_ref)
-            .unwrap_or_else(|| panic!("Unknown track layer '{}'", layer_ref));
+            .unwrap_or_else(|| panic!("Unknown track layer '{layer_ref}'"));
         let edge = self
             .get_edge(edge_index)
-            .unwrap_or_else(|| panic!("Edge index {} is out of bounds", edge_index));
+            .unwrap_or_else(|| panic!("Edge index {edge_index} is out of bounds"));
         let position = edge.get_coordinate_on_edge(&track, track_index);
         let transform = match edge.orientation() {
             Some(EdgeOrientation::North) => Mat3::identity(),


### PR DESCRIPTION
Previously, the pin spread algorithm constrained pins to be a minimum spacing apart, and ran a binary search on the minimum spacing. Now, the algorithm checks that pin placement positions lie above an "index-on-layer vs. position" line, and runs a binary search on the slope of that line. This helps to avoid quantization issues that prevented pins from being placed all the way to the edge of a range.

(This PR also includes some unrelated cleanup of clippy warnings.)