### PR TITLE
Add features for placing one pin based on another's position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.67.0"
+version = "0.68.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/examples/derived_pins.rs
+++ b/examples/derived_pins.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use topstitch::{
+    BoundingBox, Coordinate, LefDefOptions, ModDef, Orientation, Polygon, Range, SpreadPinsOptions,
+    TrackDefinition, TrackDefinitions, TrackOrientation, Usage, IO,
+};
+
+const WIDTH: i64 = 100;
+const HEIGHT: i64 = 4 * PIN_WIDTH * (NUM_PINS as i64);
+const NUM_PINS: usize = 2;
+const PIN_WIDTH: i64 = 10;
+const PIN_DEPTH: i64 = 20;
+
+fn build_leaf(
+    name: &str,
+    track_definitions: &TrackDefinitions,
+    shape: Polygon,
+) -> Result<ModDef, Box<dyn std::error::Error>> {
+    let m = ModDef::new(name);
+    m.set_shape(shape);
+    m.set_track_definitions(track_definitions.clone());
+
+    m.add_port("in", IO::Input(NUM_PINS));
+    m.add_port("out", IO::Output(NUM_PINS));
+
+    // Mark as a leaf for LEF/DEF emission
+    m.set_usage(Usage::EmitStubAndStop);
+    Ok(m)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Paths for output files under examples/output
+    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let out_dir = examples.join("output");
+    std::fs::create_dir_all(&out_dir).expect("create examples/output/");
+
+    // Track definitions
+    let mut track_definitions = TrackDefinitions::new();
+    let pin_shape = Polygon::from_bbox(&BoundingBox {
+        min_x: 0,
+        min_y: -PIN_WIDTH / 2,
+        max_x: PIN_DEPTH,
+        max_y: PIN_WIDTH / 2,
+    });
+    track_definitions.add_track(TrackDefinition::new(
+        "M1",
+        PIN_WIDTH,
+        2 * PIN_WIDTH,
+        TrackOrientation::Horizontal,
+        Some(pin_shape.clone()),
+        None,
+    ));
+
+    // Build A and B
+    let a = build_leaf(
+        "A",
+        &track_definitions,
+        Polygon::from_width_height(WIDTH, HEIGHT),
+    )?;
+    let b = build_leaf(
+        "B",
+        &track_definitions,
+        Polygon::new(vec![
+            Coordinate { x: 0, y: 0 },
+            Coordinate {
+                x: 0,
+                y: 5 * HEIGHT / 4,
+            },
+            Coordinate {
+                x: WIDTH / 2,
+                y: 5 * HEIGHT / 4,
+            },
+            Coordinate {
+                x: WIDTH / 2,
+                y: HEIGHT,
+            },
+            Coordinate {
+                x: WIDTH,
+                y: HEIGHT,
+            },
+            Coordinate { x: WIDTH, y: 0 },
+        ]),
+    )?;
+
+    let top = ModDef::new("Top");
+    let a_instance = top.instantiate(&a, Some("a_inst"), None);
+    let b_instance = top.instantiate(&b, Some("b_inst"), None);
+
+    // Coordinates chosen to cover positive and negative x and y values
+    a_instance.place((-40, -40), Orientation::R0);
+    b_instance.place(((2 * WIDTH) - 20, -20), Orientation::MY);
+
+    // Pin inputs and outputs
+    a.get_port("in").spread_pins_on_left_edge(
+        a.get_layers(),
+        SpreadPinsOptions {
+            range: Range::new(HEIGHT / 4, 3 * HEIGHT / 4),
+            ..Default::default()
+        },
+    )?;
+
+    for i in 0..NUM_PINS {
+        a_instance
+            .get_port("out")
+            .bit(i)
+            .place_across_from(a_instance.get_port("in").bit(i));
+        b_instance
+            .get_port("in")
+            .bit(i)
+            .place_from(a_instance.get_port("out").bit(i));
+        b_instance
+            .get_port("out")
+            .bit(i)
+            .place_across_from(b_instance.get_port("in").bit(i));
+    }
+
+    // Emit LEF/DEF for viewing
+    let lef_path = out_dir.join("derived_pins.lef");
+    let def_path = out_dir.join("derived_pins.def");
+    top.emit_lef_def_to_files(&lef_path, &def_path, &LefDefOptions::default())
+        .expect("emit LEF/DEF");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,10 @@ mod mod_def;
 use mod_def::ModDefCore;
 pub use mod_def::ParameterType;
 pub use mod_def::{
-    BoundingBox, CalculatedPlacement, ConvertibleToModDef, Coordinate, Mat3, ModDef, Orientation,
-    Placement, Polygon, Range, TrackDefinition, TrackDefinitions, TrackOrientation,
-    BOTTOM_EDGE_INDEX, EAST_EDGE_INDEX, LEFT_EDGE_INDEX, NORTH_EDGE_INDEX, RIGHT_EDGE_INDEX,
-    SOUTH_EDGE_INDEX, TOP_EDGE_INDEX, WEST_EDGE_INDEX,
+    BoundingBox, CalculatedPlacement, ConvertibleToModDef, Coordinate, EdgeOrientation, Mat3,
+    ModDef, Orientation, Placement, Polygon, Range, TrackDefinition, TrackDefinitions,
+    TrackOrientation, BOTTOM_EDGE_INDEX, EAST_EDGE_INDEX, LEFT_EDGE_INDEX, NORTH_EDGE_INDEX,
+    RIGHT_EDGE_INDEX, SOUTH_EDGE_INDEX, TOP_EDGE_INDEX, WEST_EDGE_INDEX,
 };
 pub mod lefdef;
 pub use lefdef::LefDefOptions;
@@ -49,5 +49,4 @@ pub use package::{
     extract_packages_from_verilog_files, extract_packages_with_config, Package, Parameter,
 };
 
-pub use mod_def::ParserConfig;
-pub use mod_def::SpreadPinsOptions;
+pub use mod_def::{ParserConfig, PhysicalPin, SpreadPinsOptions};

--- a/src/mod_def/abutment.rs
+++ b/src/mod_def/abutment.rs
@@ -9,7 +9,8 @@ impl ModDef {
     pub(crate) fn mark_adjacent(&mut self, inst_a: &ModInst, inst_b: &ModInst) {
         // Check that the two instances are in this module definition.
         for inst in [inst_a, inst_b] {
-            assert!(Rc::ptr_eq(&inst.mod_def_core.upgrade().unwrap(), &self.core),
+            let inst_core = inst.mod_def_core_where_instantiated();
+            assert!(Rc::ptr_eq(&inst_core, &self.core),
                 "Cannot annotate adjacency property for instance {} because it is not an instance of {}",
                 inst.debug_string(),
                 self.get_name()
@@ -20,9 +21,9 @@ impl ModDef {
         let mut core = self.core.borrow_mut();
         for adjacency_pair in [(inst_a, inst_b), (inst_b, inst_a)] {
             core.adjacency_matrix
-                .entry(adjacency_pair.0.name.clone())
+                .entry(adjacency_pair.0.name().to_string())
                 .or_default()
-                .insert(adjacency_pair.1.name.clone());
+                .insert(adjacency_pair.1.name().to_string());
         }
     }
 

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -45,3 +45,34 @@ pub struct ModDefCore {
     pub(crate) track_definitions: Option<TrackDefinitions>,
     pub(crate) track_occupancies: Option<TrackOccupancies>,
 }
+
+impl ModDefCore {
+    pub fn get_physical_pin(&self, port_name: &str, bit: usize) -> PhysicalPin {
+        let pins = self.physical_pins.get(port_name).unwrap_or_else(|| {
+            panic!(
+                "Physical pins for port {}.{} not defined",
+                self.name, port_name
+            )
+        });
+
+        if bit >= pins.len() {
+            panic!(
+                "Bit {} out of range for port {}.{} (width {})",
+                bit,
+                self.name,
+                port_name,
+                pins.len()
+            );
+        }
+
+        pins[bit]
+            .as_ref()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Physical pin for {}.{}[{}] is not placed",
+                    self.name, port_name, bit
+                )
+            })
+            .clone()
+    }
+}

--- a/src/mod_def/emit.rs
+++ b/src/mod_def/emit.rs
@@ -365,15 +365,16 @@ since the width of that port is {}. Check the slice indices for this instance po
                     *lsb as i64,
                 ),
                 PortSlice {
-                    port:
-                        Port::ModInst {
-                            inst_name,
-                            port_name,
-                            ..
-                        },
+                    port: Port::ModInst { .. },
                     msb,
                     lsb,
                 } => {
+                    let inst_name = lhs
+                        .port
+                        .inst_name()
+                        .expect("Port::ModInst hierarchy cannot be empty")
+                        .to_string();
+                    let port_name = lhs.port.get_port_name();
                     let net_name = format!("{inst_name}_{port_name}");
                     file.make_slice(
                         &nets.get(&net_name).unwrap().to_indexable_expr(),
@@ -393,15 +394,16 @@ since the width of that port is {}. Check the slice indices for this instance po
                     *lsb as i64,
                 ),
                 PortSlice {
-                    port:
-                        Port::ModInst {
-                            inst_name,
-                            port_name,
-                            ..
-                        },
+                    port: Port::ModInst { .. },
                     msb,
                     lsb,
                 } => {
+                    let inst_name = rhs
+                        .port
+                        .inst_name()
+                        .expect("Port::ModInst hierarchy cannot be empty")
+                        .to_string();
+                    let port_name = rhs.port.get_port_name();
                     let net_name = format!("{inst_name}_{port_name}");
                     file.make_slice(
                         &nets.get(&net_name).unwrap().to_indexable_expr(),
@@ -481,15 +483,16 @@ since the width of that port is {}. Check the slice indices for this instance po
                     msb - lsb + 1,
                 ),
                 PortSlice {
-                    port:
-                        Port::ModInst {
-                            inst_name,
-                            port_name,
-                            ..
-                        },
+                    port: Port::ModInst { .. },
                     msb,
                     lsb,
                 } => {
+                    let inst_name = dst
+                        .port
+                        .inst_name()
+                        .expect("Port::ModInst hierarchy cannot be empty")
+                        .to_string();
+                    let port_name = dst.port.get_port_name();
                     let net_name = format!("{inst_name}_{port_name}");
                     (
                         file.make_slice(

--- a/src/mod_def/instances.rs
+++ b/src/mod_def/instances.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use std::rc::Rc;
 
-use crate::{ModDef, ModInst};
+use crate::{mod_inst::HierPathElem, ModDef, ModInst};
 
 impl ModDef {
     /// Returns a vector of all module instances within this module definition.
@@ -13,8 +13,10 @@ impl ModDef {
             .instances
             .keys()
             .map(|name| ModInst {
-                name: name.clone(),
-                mod_def_core: Rc::downgrade(&self.core),
+                hierarchy: vec![HierPathElem {
+                    mod_def_core: Rc::downgrade(&self.core),
+                    inst_name: name.clone(),
+                }],
             })
             .collect()
     }
@@ -25,8 +27,10 @@ impl ModDef {
         let inner = self.core.borrow();
         if inner.instances.contains_key(name.as_ref()) {
             ModInst {
-                name: name.as_ref().to_string(),
-                mod_def_core: Rc::downgrade(&self.core),
+                hierarchy: vec![HierPathElem {
+                    mod_def_core: Rc::downgrade(&self.core),
+                    inst_name: name.as_ref().to_string(),
+                }],
             }
         } else {
             panic!("Instance {}.{} does not exist", inner.name, name.as_ref())
@@ -80,8 +84,10 @@ impl ModDef {
 
         // Create the ModInst
         let inst = ModInst {
-            name: name.to_string(),
-            mod_def_core: Rc::downgrade(&self.core),
+            hierarchy: vec![HierPathElem {
+                mod_def_core: Rc::downgrade(&self.core),
+                inst_name: name.to_string(),
+            }],
         };
 
         // autoconnect logic

--- a/src/mod_def/pins.rs
+++ b/src/mod_def/pins.rs
@@ -819,6 +819,11 @@ impl ModDef {
         }
         layers_map
     }
+
+    pub fn get_physical_pin(&self, port_name: &str, bit: usize) -> PhysicalPin {
+        let core = self.core.borrow();
+        core.get_physical_pin(port_name, bit)
+    }
 }
 
 macro_rules! place_port_slice_on_named_edge {

--- a/src/mod_def/tracks.rs
+++ b/src/mod_def/tracks.rs
@@ -172,6 +172,22 @@ impl TrackDefinition {
     pub fn index_to_position(&self, index: i64) -> i64 {
         self.offset + (index * self.period)
     }
+
+    /// Returns the nearest track index (in track coordinates, before
+    /// edge-relative normalization) to the provided coordinate.
+    pub fn nearest_track_index(&self, coordinate: i64) -> i64 {
+        assert!(self.period != 0, "Track period must be non-zero");
+        let n = coordinate - self.offset;
+        let p = self.period;
+        let mut q = n / p;
+        let r = n % p;
+
+        if 2 * r.abs() >= p.abs() {
+            q += if n >= 0 { 1 } else { -1 };
+        }
+
+        q
+    }
 }
 
 /// Collection of track definitions keyed by layer name.

--- a/src/mod_inst.rs
+++ b/src/mod_inst.rs
@@ -1,30 +1,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::rc::Weak;
+use std::rc::{Rc, Weak};
 
 use crate::{ConvertibleToModDef, Intf, ModDef, ModDefCore, Port, PortSlice};
-use crate::{Coordinate, Orientation, Placement};
+use crate::{Coordinate, Mat3, Orientation, Placement, Polygon};
 
 /// Represents an instance of a module definition, like `<mod_def_name>
 /// <mod_inst_name> ( ... );` in Verilog.
-#[derive(Clone)]
-pub struct ModInst {
-    pub(crate) name: String,
+#[derive(Clone, Debug)]
+pub struct HierPathElem {
     pub(crate) mod_def_core: Weak<RefCell<ModDefCore>>,
+    pub(crate) inst_name: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ModInst {
+    pub(crate) hierarchy: Vec<HierPathElem>,
 }
 
 impl ModInst {
+    pub(crate) fn mod_def_core_where_instantiated(&self) -> Rc<RefCell<ModDefCore>> {
+        self.hierarchy
+            .last()
+            .expect("ModInst hierarchy cannot be empty")
+            .mod_def_core
+            .upgrade()
+            .expect("Containing ModDefCore has been dropped")
+    }
+
+    pub(crate) fn mod_def_core_where_instantiated_weak(&self) -> Weak<RefCell<ModDefCore>> {
+        self.hierarchy
+            .last()
+            .expect("ModInst hierarchy cannot be empty")
+            .mod_def_core
+            .clone()
+    }
+
+    fn mod_def_core_of_instance(&self) -> Rc<RefCell<ModDefCore>> {
+        let inst_name = self.name().to_string();
+        self.mod_def_core_where_instantiated()
+            .borrow()
+            .instances
+            .get(&inst_name)
+            .unwrap_or_else(|| panic!("Instance named {} not found", inst_name))
+            .clone()
+    }
+
     /// Returns the name of this module instance.
     pub fn name(&self) -> &str {
-        &self.name
+        &self
+            .hierarchy
+            .last()
+            .expect("ModInst hierarchy cannot be empty")
+            .inst_name
     }
 
     /// Returns `true` if this module instance has an interface with the given
     /// name.
     pub fn has_intf(&self, name: impl AsRef<str>) -> bool {
         ModDef {
-            core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
+            core: self.mod_def_core_of_instance(),
         }
         .has_intf(name)
     }
@@ -32,7 +68,7 @@ impl ModInst {
     /// Returns `true` if this module instance has a port with the given name.
     pub fn has_port(&self, name: impl AsRef<str>) -> bool {
         ModDef {
-            core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
+            core: self.mod_def_core_of_instance(),
         }
         .has_port(name)
     }
@@ -40,14 +76,47 @@ impl ModInst {
     /// First, get the module definition for this instance. Then, return the
     /// module instance with the given name in that module defintion.
     pub fn get_instance(&self, name: impl AsRef<str>) -> ModInst {
-        self.get_mod_def().get_instance(name)
+        let child = self.get_mod_def().get_instance(name.as_ref());
+        let mut combined = self.hierarchy.clone();
+        for frame in &child.hierarchy {
+            combined.push(frame.clone());
+        }
+        ModInst {
+            hierarchy: combined,
+        }
+    }
+
+    /// Returns the cumulative placement transform for this instance, combining
+    /// every placed level in the hierarchy.
+    pub fn get_transform(&self) -> Mat3 {
+        let mut total = Mat3::identity();
+
+        for frame in &self.hierarchy {
+            let core = frame.mod_def_core.upgrade().unwrap_or_else(|| {
+                panic!(
+                    "Containing ModDefCore for '{}' has been dropped",
+                    frame.inst_name
+                )
+            });
+
+            let placement = {
+                let core_borrowed = core.borrow();
+                core_borrowed.inst_placements.get(&frame.inst_name).copied()
+            };
+
+            if let Some(placement) = placement {
+                total = &total * &placement.transform();
+            }
+        }
+
+        total
     }
 
     /// Returns the port on this instance with the given name. Panics if no such
     /// port exists.
     pub fn get_port(&self, name: impl AsRef<str>) -> Port {
         ModDef {
-            core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
+            core: self.mod_def_core_of_instance(),
         }
         .get_port(name)
         .assign_to_inst(self)
@@ -63,7 +132,7 @@ impl ModInst {
     /// ports if `prefix` is `None`.
     pub fn get_ports(&self, prefix: Option<&str>) -> Vec<Port> {
         let result = ModDef {
-            core: self.mod_def_core.upgrade().unwrap().borrow().instances[&self.name].clone(),
+            core: self.mod_def_core_of_instance(),
         }
         .get_ports(prefix);
         result
@@ -75,10 +144,10 @@ impl ModInst {
     /// Returns the interface on this instance with the given name. Panics if no
     /// such interface exists.
     pub fn get_intf(&self, name: impl AsRef<str>) -> Intf {
-        let mod_def_core = self.mod_def_core.upgrade().unwrap();
+        let mod_def_core = self.mod_def_core_where_instantiated();
         let instances = &mod_def_core.borrow().instances;
 
-        let inst_core = match instances.get(&self.name) {
+        let inst_core = match instances.get(self.name()) {
             Some(inst_core) => inst_core.clone(),
             None => panic!(
                 "Interface '{}' does not exist on module definition '{}'",
@@ -92,8 +161,8 @@ impl ModInst {
         if inst_core_borrowed.interfaces.contains_key(name.as_ref()) {
             Intf::ModInst {
                 intf_name: name.as_ref().to_string(),
-                inst_name: self.name.clone(),
-                mod_def_core: self.mod_def_core.clone(),
+                inst_name: self.name().to_string(),
+                mod_def_core: self.mod_def_core_where_instantiated_weak(),
             }
         } else {
             panic!(
@@ -107,31 +176,26 @@ impl ModInst {
     /// Returns the ModDef that this is an instance of.
     pub fn get_mod_def(&self) -> ModDef {
         ModDef {
-            core: self
-                .mod_def_core
-                .upgrade()
-                .unwrap()
-                .borrow()
-                .instances
-                .get(&self.name)
-                .unwrap_or_else(|| panic!("Instance named {} not found", self.name))
-                .clone(),
+            core: self.mod_def_core_of_instance(),
         }
     }
 
     pub(crate) fn debug_string(&self) -> String {
-        format!(
-            "{}.{}",
-            self.mod_def_core.upgrade().unwrap().borrow().name,
-            self.name
-        )
+        let mut parts = Vec::new();
+        if let Some(frame) = self.hierarchy.first() {
+            parts.push(frame.mod_def_core.upgrade().unwrap().borrow().name.clone());
+        }
+        for frame in &self.hierarchy {
+            parts.push(frame.inst_name.clone());
+        }
+        parts.join(".")
     }
 
     /// Indicate that this instance is adjacent to another instance for
     /// the purpose of checking abuted connections.
     pub fn mark_adjacent_to(&self, other: &ModInst) {
         ModDef {
-            core: self.mod_def_core.upgrade().unwrap().clone(),
+            core: self.mod_def_core_where_instantiated(),
         }
         .mark_adjacent(self, other);
     }
@@ -139,19 +203,34 @@ impl ModInst {
     /// Indicate that this instance should not be considered for abutment
     /// checking.
     pub fn ignore_adjacency(&self) {
-        self.mod_def_core
-            .upgrade()
-            .unwrap()
+        self.mod_def_core_where_instantiated()
             .borrow_mut()
             .ignore_adjacency
-            .insert(self.name.clone());
+            .insert(self.name().to_string());
+    }
+
+    /// Define a physical pin for this instance. The provided `position` is
+    /// interpreted in the parent module's coordinate space.
+    pub fn place_pin(
+        &self,
+        port_name: impl AsRef<str>,
+        bit: usize,
+        layer: impl AsRef<str>,
+        position: Coordinate,
+        polygon: Polygon,
+    ) {
+        let inverse = self.get_transform().inverse();
+        let local_position = position.apply_transform(&inverse);
+
+        self.get_mod_def()
+            .place_pin(port_name, bit, layer, local_position, polygon);
     }
 
     /// Place this instance at a coordinate with an orientation.
     pub fn place<C: Into<Coordinate>>(&self, coordinate: C, orientation: Orientation) {
-        let core = self.mod_def_core.upgrade().unwrap();
+        let core = self.mod_def_core_where_instantiated();
         core.borrow_mut().inst_placements.insert(
-            self.name.clone(),
+            self.name().to_string(),
             Placement {
                 coordinate: coordinate.into(),
                 orientation,
@@ -169,5 +248,164 @@ impl ConvertibleToModDef for ModInst {
     }
     fn get_intf(&self, name: impl AsRef<str>) -> Intf {
         self.get_intf(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Polygon, IO};
+
+    #[test]
+    fn mod_inst_hierarchy_extends_with_get_instance() {
+        let mod_c = ModDef::new("C");
+
+        let mod_b = ModDef::new("B");
+        mod_b.instantiate(&mod_c, Some("c_inst"), None);
+
+        let mod_a = ModDef::new("A");
+        mod_a.instantiate(&mod_b, Some("b_inst"), None);
+
+        let b_inst = mod_a.get_instance("b_inst");
+        assert_eq!(b_inst.debug_string(), "A.b_inst");
+        assert_eq!(b_inst.hierarchy.len(), 1);
+        assert_eq!(b_inst.hierarchy[0].inst_name, "b_inst");
+        assert_eq!(
+            b_inst.hierarchy[0]
+                .mod_def_core
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .name,
+            "A"
+        );
+
+        let c_from_b = b_inst.get_instance("c_inst");
+        assert_eq!(c_from_b.debug_string(), "A.b_inst.c_inst");
+        assert_eq!(c_from_b.name(), "c_inst");
+        assert_eq!(c_from_b.get_mod_def().get_name(), "C");
+        assert_eq!(c_from_b.hierarchy.len(), 2);
+        assert_eq!(c_from_b.hierarchy[0].inst_name, "b_inst");
+        assert_eq!(c_from_b.hierarchy[1].inst_name, "c_inst");
+        assert_eq!(
+            c_from_b.hierarchy[0]
+                .mod_def_core
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .name,
+            "A"
+        );
+        assert_eq!(
+            c_from_b.hierarchy[1]
+                .mod_def_core
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .name,
+            "B"
+        );
+
+        let c_direct = mod_b.get_instance("c_inst");
+        assert_eq!(c_direct.debug_string(), "B.c_inst");
+        assert_eq!(c_direct.hierarchy.len(), 1);
+        assert_eq!(c_direct.hierarchy[0].inst_name, "c_inst");
+        assert_eq!(
+            c_direct.hierarchy[0]
+                .mod_def_core
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .name,
+            "B"
+        );
+    }
+
+    #[test]
+    fn mod_inst_debug_string_handles_deep_hierarchy() {
+        let mod_d = ModDef::new("D");
+
+        let mod_c = ModDef::new("C");
+        mod_c.instantiate(&mod_d, Some("d_inst"), None);
+
+        let mod_b = ModDef::new("B");
+        mod_b.instantiate(&mod_c, Some("c_inst"), None);
+
+        let mod_a = ModDef::new("A");
+        mod_a.instantiate(&mod_b, Some("b_inst"), None);
+
+        let d_from_a = mod_a
+            .get_instance("b_inst")
+            .get_instance("c_inst")
+            .get_instance("d_inst");
+
+        assert_eq!(d_from_a.debug_string(), "A.b_inst.c_inst.d_inst");
+        assert_eq!(d_from_a.hierarchy.len(), 3);
+        assert_eq!(d_from_a.hierarchy[0].inst_name, "b_inst");
+        assert_eq!(d_from_a.hierarchy[1].inst_name, "c_inst");
+        assert_eq!(d_from_a.hierarchy[2].inst_name, "d_inst");
+    }
+
+    #[test]
+    fn mod_inst_transform_and_port_coordinate() {
+        let leaf = ModDef::new("Leaf");
+        leaf.add_port("p", IO::Output(1));
+        leaf.place_pin(
+            "p",
+            0,
+            "M1",
+            Coordinate { x: 2, y: 3 },
+            Polygon::from_width_height(1, 1),
+        );
+
+        let mid = ModDef::new("Mid");
+        let leaf_inst = mid.instantiate(&leaf, Some("leaf"), None);
+        leaf_inst.place((5, 0), Orientation::R90);
+
+        let top = ModDef::new("Top");
+        let mid_inst = top.instantiate(&mid, Some("mid"), None);
+        mid_inst.place((10, -2), Orientation::R0);
+
+        let leaf_from_top = mid_inst.get_instance("leaf");
+        let total_transform = leaf_from_top.get_transform();
+
+        let pin_world = leaf_from_top.get_port("p").bit(0).get_coordinate();
+        assert_eq!(
+            pin_world,
+            Coordinate { x: 2, y: 3 }.apply_transform(&total_transform)
+        );
+        assert_eq!(pin_world, Coordinate { x: 12, y: 0 });
+
+        let recovered_local = pin_world.apply_transform(&total_transform.inverse());
+        assert_eq!(recovered_local, Coordinate { x: 2, y: 3 });
+
+        // Re-place the pin through the instance using parent-space coordinates.
+        let polygon = Polygon::from_width_height(1, 1);
+        leaf_from_top.place_pin("p", 0, "M1", pin_world, polygon.clone());
+
+        // The underlying module stores pins in local coordinates.
+        let local_coord = leaf.get_port("p").bit(0).get_coordinate();
+        assert_eq!(local_coord, Coordinate { x: 2, y: 3 });
+    }
+
+    #[test]
+    fn mod_inst_place_pin_inverts_transform() {
+        let child = ModDef::new("Child");
+        child.add_port("x", IO::Output(1));
+
+        let parent = ModDef::new("Parent");
+        let child_inst = parent.instantiate(&child, Some("c"), None);
+        child_inst.place((10, 5), Orientation::R180);
+
+        let world_coord = Coordinate { x: 8, y: 7 };
+        let polygon = Polygon::from_width_height(2, 3);
+        child_inst.place_pin("x", 0, "M2", world_coord, polygon.clone());
+
+        // The stored pin should reside in child-local space.
+        let core = child.core.borrow();
+        let pins = core.physical_pins.get("x").unwrap();
+        let stored_pin = pins[0].as_ref().unwrap();
+        let expected_local = world_coord.apply_transform(&child_inst.get_transform().inverse());
+        assert_eq!(stored_pin.position, expected_local);
     }
 }

--- a/src/port_slice/tieoff.rs
+++ b/src/port_slice/tieoff.rs
@@ -17,20 +17,21 @@ impl PortSlice {
             .tieoffs
             .push(((*self).clone(), big_int_value.clone()));
 
-        if let Port::ModInst {
-            inst_name,
-            port_name,
-            ..
-        } = &self.port
-        {
+        if let Port::ModInst { .. } = &self.port {
             if self.port.io().width() == self.width() {
                 // whole port tieoff
+                let inst_name = self
+                    .port
+                    .inst_name()
+                    .expect("Port::ModInst hierarchy cannot be empty")
+                    .to_string();
+                let port_name = self.port.get_port_name();
                 mod_def_core
                     .borrow_mut()
                     .whole_port_tieoffs
-                    .entry(inst_name.clone())
+                    .entry(inst_name)
                     .or_default()
-                    .insert(port_name.clone(), big_int_value);
+                    .insert(port_name, big_int_value);
             }
         }
     }
@@ -43,20 +44,21 @@ impl PortSlice {
         let mod_def_core = self.get_mod_def_core();
         mod_def_core.borrow_mut().unused.push((*self).clone());
 
-        if let Port::ModInst {
-            inst_name,
-            port_name,
-            ..
-        } = &self.port
-        {
+        if let Port::ModInst { .. } = &self.port {
             if self.port.io().width() == self.width() {
                 // the whole port is unnused
+                let inst_name = self
+                    .port
+                    .inst_name()
+                    .expect("Port::ModInst hierarchy cannot be empty")
+                    .to_string();
+                let port_name = self.port.get_port_name();
                 mod_def_core
                     .borrow_mut()
                     .whole_port_unused
-                    .entry(inst_name.clone())
+                    .entry(inst_name)
                     .or_default()
-                    .insert(port_name.clone());
+                    .insert(port_name);
             }
         }
     }


### PR DESCRIPTION
This PR adds several features for placing one pin with respect to another, the key ones being:

* `pin1.place_across_from(pin2)`: Place one pin directly opposite another pin. `pin1` and `pin2` need to be in the same module.
* `pin1.place_from(pin2)`: Place one pin abutting another pin (or as close as possible, if there is a gap between modules). `pin1` and `pin2` are generally in different module instances in this case. This function takes into account module placement and orientation.

These features are demonstrated in new example code, `examples/derived_pins.rs`. They allow users to define an algorithm for pinning, in this case:
1. Spreading input pins on the left edge of `A`
2. Copying those pin locations across the block to become output pins.
3. Defining input pin locations on `B` based on the output pin locations of `A`, taking into account the position and orientation of `A` and `B`.
4. Copying the input pins of `B` across the block to become output pins. Note that "copy across" works for rectilinear blocks, as shown here.

The new features allow users to describe these operations without reference to many geometric details; these are mostly handled under the hood. In a future PR, I will further simplify `place_from` by automatically determining the driver of a pin from TopStitch connectivity information.

```rust
a.get_port("in").spread_pins_on_left_edge(
    a.get_layers(),
    SpreadPinsOptions { range: Range::new(HEIGHT / 4, 3 * HEIGHT / 4), ..Default::default() },
)?;

for i in 0..NUM_PINS {
    a_inst.get_port("out").bit(i).place_across_from(a_inst.get_port("in").bit(i));
    b_inst.get_port("in").bit(i).place_from(a_inst.get_port("out").bit(i));
    b_inst.get_port("out").bit(i).place_across_from(b_inst.get_port("in").bit(i));
}
```

<img width="1074" height="641" alt="image" src="https://github.com/user-attachments/assets/041eff07-7640-41ad-8ab0-e6d719c536a1" />
