### PR TITLE
New data structures for representing connectivity (in parallel to existing, for now)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.68.0"
+version = "0.69.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pub mod connected_item;
+pub mod expression_source;
+pub mod port_slice;
+
+pub use port_slice::PortSliceConnections;

--- a/src/connection/connected_item.rs
+++ b/src/connection/connected_item.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use num_bigint::BigInt;
+use std::fmt::{self, Debug};
+
+use crate::connection::port_slice::PortSliceConnections;
+use crate::PortSlice;
+
+/// Represents what a PortSlice is connected to: another
+/// PortSlice, a tieoff, an "unused" marker, or a wire.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectedItem {
+    PortSlice(PortSlice),
+    Tieoff(Tieoff),
+    Unused,
+    Wire(Wire),
+}
+
+/// Represents a tieoff connected to a PortSlice.
+#[derive(Clone, PartialEq)]
+pub struct Tieoff {
+    pub value: BigInt,
+}
+
+impl Tieoff {
+    pub fn new<T: Into<BigInt>>(value: T) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+
+    /// Returns a new Tieoff value that is a slice of this one, with the given
+    /// offset and width.
+    pub fn slice_with_offset_and_width(&self, offset: usize, width: usize) -> Tieoff {
+        let mask = (BigInt::from(1u32) << width) - 1;
+        Tieoff::new(self.value.clone() >> offset & mask)
+    }
+}
+
+impl Debug for Tieoff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x({:X})", self.value)
+    }
+}
+
+/// Represents a wire name specification for a PortSlice. `width` represents the
+/// full width of the wire, while `msb` and `lsb` define a slice of the wire
+/// that is connected to the PortSlice. `msb` - `lsb` + 1 <= `width`. Slicing a
+/// wire multiple times changes `msb` and `lsb`, but not `width`. This is
+/// convenient because any PortSlice connected to the wire has the full
+/// information needed to declare the wire.
+#[derive(Clone, PartialEq)]
+pub struct Wire {
+    pub name: String,
+    pub width: usize,
+    pub msb: usize,
+    pub lsb: usize,
+}
+
+impl Wire {
+    /// Returns a new Wire with the same `name` and `width`, but `msb` and `lsb`
+    /// adjusted according to the given offset and width.
+    pub fn slice_with_offset_and_width(&self, offset: usize, width: usize) -> Wire {
+        let lsb = self.lsb + offset;
+        let msb = lsb + width - 1;
+
+        Wire {
+            name: self.name.clone(),
+            width: self.width,
+            msb,
+            lsb,
+        }
+    }
+}
+
+impl Debug for Wire {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}[{}:{}]", self.name, self.msb, self.lsb)
+    }
+}
+
+impl ConnectedItem {
+    pub fn slice_with_offset_and_width(&self, offset: usize, width: usize) -> ConnectedItem {
+        match self {
+            ConnectedItem::PortSlice(port_slice) => {
+                port_slice.slice_with_offset_and_width(offset, width).into()
+            }
+            ConnectedItem::Tieoff(tieoff) => {
+                tieoff.slice_with_offset_and_width(offset, width).into()
+            }
+            ConnectedItem::Unused => ConnectedItem::Unused,
+            ConnectedItem::Wire(wire) => wire.slice_with_offset_and_width(offset, width).into(),
+        }
+    }
+}
+
+impl PortSliceConnections {
+    /// Returns a vector of all tieoff connections
+    pub fn to_tieoffs(&self) -> Vec<Tieoff> {
+        let mut result = Vec::new();
+        for connection in self {
+            if let ConnectedItem::Tieoff(tieoff) = &connection.other {
+                result.push(tieoff.clone());
+            }
+        }
+        result
+    }
+
+    /// Returns a vector of all wire name specifications
+    pub fn to_wires(&self) -> Vec<Wire> {
+        let mut result = Vec::new();
+        for connection in self {
+            if let ConnectedItem::Wire(wire) = &connection.other {
+                result.push(wire.clone());
+            }
+        }
+        result
+    }
+
+    /// Returns a vector of all port slice connections
+    pub fn to_port_slices(&self) -> Vec<PortSlice> {
+        let mut result = Vec::new();
+        if !self.is_empty() {
+            result.push(self[0].this.clone());
+        }
+        for connection in self {
+            if let ConnectedItem::PortSlice(port_slice) = &connection.other {
+                result.push(port_slice.clone());
+            }
+        }
+        result
+    }
+
+    /// Returns the number of "unused" connections
+    pub fn to_unused_count(&self) -> usize {
+        let mut result = 0;
+        for connection in self {
+            if let ConnectedItem::Unused = &connection.other {
+                result += 1;
+            }
+        }
+        result
+    }
+}
+
+impl PartialEq<PortSlice> for ConnectedItem {
+    fn eq(&self, other: &PortSlice) -> bool {
+        matches!(self, ConnectedItem::PortSlice(ps) if ps == other)
+    }
+}
+
+impl PartialEq<ConnectedItem> for PortSlice {
+    fn eq(&self, other: &ConnectedItem) -> bool {
+        matches!(other, ConnectedItem::PortSlice(ps) if self == ps)
+    }
+}
+
+// Ergonomic conversions to ConnectedItem
+impl From<PortSlice> for ConnectedItem {
+    fn from(value: PortSlice) -> Self {
+        ConnectedItem::PortSlice(value)
+    }
+}
+
+impl From<Tieoff> for ConnectedItem {
+    fn from(value: Tieoff) -> Self {
+        ConnectedItem::Tieoff(value)
+    }
+}
+
+impl From<Wire> for ConnectedItem {
+    fn from(value: Wire) -> Self {
+        ConnectedItem::Wire(value)
+    }
+}

--- a/src/connection/expression_source.rs
+++ b/src/connection/expression_source.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::port_slice::PortSliceConnections;
+use crate::{Port, IO};
+
+use super::connected_item::ConnectedItem;
+
+impl PortSliceConnections {
+    /// Returns a ConnectedItem (PortSlice, tieoff, etc.) indicating the source
+    /// of the expression connected to this port slice to be used when
+    /// emitting Verilog code. For example, if a ModInst output is connected to
+    /// a ModInst input, the expression source will be the ModInst output port
+    /// slice, unless overridden by a wire name specification. If a ModInst
+    /// output is connected to a ModDef output, the expression source will be
+    /// the ModDef output port slice, to avoid creating an unnecessary wire.
+    pub fn to_expression_source(&self) -> Option<ConnectedItem> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let this = self[0].this.clone();
+        let this_debug_string = this.debug_string();
+
+        let unused_count = self.to_unused_count();
+        let tieoffs = self.to_tieoffs();
+        let wires = self.to_wires();
+        let port_slices = self.to_port_slices();
+
+        ///////////////////////////////
+        // handle an "unused" marker //
+        ///////////////////////////////
+
+        match unused_count {
+            0 => {}
+            1 => {
+                assert!(
+                    tieoffs.is_empty(),
+                    "{this_debug_string} is unused, so it cannot also be tied off"
+                );
+                assert!(
+                    wires.is_empty(),
+                    "{this_debug_string} is unused, so it cannot also be connected to a wire"
+                );
+                assert!(
+                    port_slices.len() == 1,
+                    "{this_debug_string} is unused, so it cannot be connected to other ports or port slices"
+                );
+                let io = this.port.io();
+                assert!(
+                    matches!(
+                        (&this.port, io),
+                        (Port::ModDef { .. }, IO::Input(_))
+                            | (Port::ModInst { .. }, IO::Output(_))
+                            | (Port::ModDef { .. }, IO::InOut(_))
+                            | (Port::ModInst { .. }, IO::InOut(_))
+                    ),
+                    "{this_debug_string} cannot be marked as unused because it has an incompatible directionality"
+                );
+                return Some(ConnectedItem::Unused);
+            }
+            _ => {
+                panic!("{this_debug_string} has been marked as unused multiple times");
+            }
+        }
+
+        /////////////////////
+        // handle a tieoff //
+        /////////////////////
+
+        match tieoffs.len() {
+            0 => {}
+            1 => {
+                assert!(
+                    wires.is_empty(),
+                    "{this_debug_string} is tied off, so it cannot also be connected to a wire"
+                );
+                let io = this.port.io();
+                match (&this.port, io) {
+                    (Port::ModDef { .. }, IO::Output(_)) | (Port::ModInst { .. }, IO::Input(_)) => {
+                        return Some(ConnectedItem::Tieoff(tieoffs[0].clone()));
+                    }
+                    _ => {
+                        panic!("{this_debug_string} has the wrong directionality to be tied off");
+                    }
+                };
+            }
+            _ => {
+                panic!("{this_debug_string} has been tied off multiple times");
+            }
+        }
+
+        ////////////////////////////////////
+        // handle port slices connections //
+        ////////////////////////////////////
+
+        let mut mod_def_inouts = Vec::new();
+        let mut mod_def_inputs = Vec::new();
+        let mut mod_def_outputs = Vec::new();
+        let mut mod_inst_outputs = Vec::new();
+        let mut mod_inst_inouts = Vec::new();
+        for port_slice in port_slices {
+            match (&port_slice.port, port_slice.port.io()) {
+                (Port::ModDef { .. }, IO::Input(_)) => mod_def_inputs.push(port_slice),
+                (Port::ModDef { .. }, IO::Output(_)) => mod_def_outputs.push(port_slice),
+                (Port::ModDef { .. }, IO::InOut(_)) => mod_def_inouts.push(port_slice),
+                (Port::ModInst { .. }, IO::Output(_)) => mod_inst_outputs.push(port_slice),
+                (Port::ModInst { .. }, IO::InOut(_)) => mod_inst_inouts.push(port_slice),
+                // No action needed in this case, because ModInst inputs never control
+                // the net name.
+                (Port::ModInst { .. }, IO::Input(_)) => {}
+            }
+        }
+
+        // collapse ModDef inputs to at most one (or error out)
+        assert!(
+            mod_def_inputs.len() <= 1,
+            "{this_debug_string} is multiply driven"
+        );
+        let mod_def_input = mod_def_inputs.first().cloned();
+
+        // collapse ModInst outputs to at most one (or error out)
+        assert!(
+            mod_inst_outputs.len() <= 1,
+            "{this_debug_string} is multiply driven"
+        );
+        let mod_inst_output = mod_inst_outputs.first().cloned();
+
+        // make sure we don't have both a ModDef input and a ModInst output
+        assert!(
+            !(mod_def_input.is_some() && mod_inst_output.is_some()),
+            "{this_debug_string} is multiply driven"
+        );
+
+        // collapse ModDef inouts to at most one (or error out)
+        assert!(
+            mod_def_inouts.len() <= 1,
+            "{this_debug_string} is connected to multiple ModDef inout ports, which is not allowed"
+        );
+        let mod_def_inout = mod_def_inouts.first().cloned();
+
+        // InOuts are effectively treated as outputs for the purpose of determining the
+        // expression source. There are a few additional restrictions that are checked
+        // below:
+        // 1. A ModDef InOut cannot be connected to a ModDef Input or Output
+        // 2. A ModInst InOut cannot be connected to a ModInst Input or Output
+
+        let mod_def_outputs_or_inouts = if let Some(mod_def_inout) = mod_def_inout {
+            assert!(
+                mod_def_input.is_none(),
+                "Cannot have both ModDef Input and ModDef InOut for {this_debug_string}"
+            );
+            assert!(
+                mod_def_outputs.is_empty(),
+                "Cannot have both ModDef Outputs and ModDef InOuts for {this_debug_string}"
+            );
+            vec![mod_def_inout]
+        } else {
+            mod_def_outputs
+        };
+
+        let mod_inst_output_or_inout = if mod_inst_inouts.is_empty() {
+            mod_inst_output
+        } else {
+            assert!(
+                mod_inst_output.is_none(),
+                "Cannot have both a ModInst Output and a ModInst InOut for {this_debug_string}"
+            );
+            // Mechanism for determing the "prevailing" ModInst port slice in a way that
+            // will yield the same result for all PortSlices on this net: sort by
+            // the instance name and then the port name on the instance. Note that because
+            // this will not necessarily yield a "nice" name, it is always possible to
+            // override this with a wire connection.
+            Some(
+                mod_inst_inouts
+                    .into_iter()
+                    .min_by_key(|port_slice| {
+                        (
+                            port_slice.get_inst_name().unwrap_or_default(),
+                            port_slice.port.name().to_string(),
+                        )
+                    })
+                    .unwrap(),
+            )
+        };
+
+        assert!(
+            mod_def_input.is_some() || mod_inst_output_or_inout.is_some(),
+            "No driver found for {this_debug_string}"
+        );
+
+        // The "prevailing" port slice is the one that will be used as
+        // the expression source when emitting Verilog code, unless there
+        // is also a wire connection.
+
+        let prevailing_port_slice = if let Some(mod_def_input) = mod_def_input {
+            mod_def_input
+        } else {
+            match mod_def_outputs_or_inouts.len() {
+                0 => {
+                    // No ModDef ports at all, so use the ModInst Output or InOut port
+                    // Note that there can be multiple ModInst InOuts, but they are
+                    // already reduced to a single "prevailing" PortSlice by this point.
+                    mod_inst_output_or_inout
+                        .unwrap_or_else(|| panic!("No driver found for {this_debug_string}"))
+                }
+                1 => {
+                    // One ModDef Output or InOut, and no ModDef Inputs. In this case, the
+                    // ModDef port prevails. Anything else connected to it can simply use
+                    // the ModDef port name to connect, without an intermediate wire.
+                    mod_def_outputs_or_inouts[0].clone()
+                }
+                _ => mod_inst_output_or_inout
+                    .unwrap_or_else(|| panic!("No driver found for {this_debug_string}")),
+            }
+        };
+
+        //////////////////////////////
+        // handle a wire connection //
+        //////////////////////////////
+
+        match wires.len() {
+            0 => Some(ConnectedItem::PortSlice(prevailing_port_slice)),
+            1 => {
+                let io = prevailing_port_slice.port.io();
+                assert!(
+                    !matches!(
+                        (prevailing_port_slice.port, io),
+                        (Port::ModDef { .. }, IO::Input(_))
+                    ),
+                    "A wire cannot be attached to {this_debug_string} because it is a ModDef Input"
+                );
+                Some(ConnectedItem::Wire(wires[0].clone()))
+            }
+            _ => {
+                panic!("Multiple wires connections found for {this_debug_string}");
+            }
+        }
+    }
+}

--- a/src/connection/port_slice.rs
+++ b/src/connection/port_slice.rs
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::PortSlice;
+use std::collections::HashSet;
+use std::ops::Index;
+
+use super::connected_item::ConnectedItem;
+
+/// Describes a connection between a PortSlice and something else (another
+/// PortSlice, a tieoff, etc.). Does not convey the directionality of the
+/// connection, i.e. `this`` may drive `other`, `other` may drive `this`, or the
+/// connection may be bidirectional.
+#[derive(Clone, Debug)]
+pub struct PortSliceConnection {
+    pub(crate) this: PortSlice,
+    pub(crate) other: ConnectedItem,
+}
+
+/// PortSliceConnection collection. This is used within ModDefCore to track
+/// connections at the Port level.
+#[derive(Clone, Debug, Default)]
+pub struct PortSliceConnections {
+    connections: Vec<PortSliceConnection>,
+}
+
+impl Index<usize> for PortSliceConnections {
+    type Output = PortSliceConnection;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.connections[index]
+    }
+}
+
+impl<'a> IntoIterator for &'a PortSliceConnections {
+    type Item = &'a PortSliceConnection;
+    type IntoIter = std::slice::Iter<'a, PortSliceConnection>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.connections.iter()
+    }
+}
+
+impl PortSliceConnections {
+    pub fn new() -> Self {
+        Self {
+            connections: Vec::new(),
+        }
+    }
+
+    /// Adds a new connection between `this` and `other`
+    pub fn add(&mut self, this: PortSlice, other: impl Into<ConnectedItem>) {
+        self.connections.push(PortSliceConnection {
+            this,
+            other: other.into(),
+        });
+    }
+
+    /// Returns a new `PortSliceConnections` that is a slice of this one,
+    /// meaning connections are clipped to the specified `msb` and `lsb`
+    /// range.
+    pub fn slice(&self, msb: usize, lsb: usize) -> PortSliceConnections {
+        let mut result = PortSliceConnections::new();
+        for connection in self {
+            // Skip connection if there is no overlap with the requested range.
+            if msb < connection.this.lsb || connection.this.msb < lsb {
+                continue;
+            }
+
+            // Clip "this" side of the slice to the requested range.
+            let this_lsb_clipped = lsb.max(connection.this.lsb);
+            let this_msb_clipped = msb.min(connection.this.msb);
+
+            let this_slice = connection
+                .this
+                .port
+                .slice(this_msb_clipped, this_lsb_clipped);
+            let other_sliced = connection.other.slice_with_offset_and_width(
+                this_lsb_clipped - connection.this.lsb,
+                this_msb_clipped - this_lsb_clipped + 1,
+            );
+            result.add(this_slice, other_sliced);
+        }
+
+        result
+    }
+
+    /// Returns a new `PortSliceConnections` that recursively traces all
+    /// `PortSlice` connection arcs. In the result, `this` still refers to the
+    /// same port as in `self`, effectively collapsing multi-hop connections in
+    /// the connection graph.
+    pub fn trace(&self) -> PortSliceConnections {
+        let mut result = PortSliceConnections::new();
+        for connection in self {
+            result.extend(connection.trace());
+        }
+        result
+    }
+
+    /// Returns a new `PortSliceConnections` in which the starting points of the
+    /// connection arcs are non-overlapping. This is important for resolving the
+    /// expression source for a port slice for Verilog code generation, and may
+    /// also be used for physical pin location derivation in the future.
+    #[allow(dead_code)] // TODO: work in progress - remove this
+    pub(crate) fn make_non_overlapping(&self) -> Vec<PortSliceConnections> {
+        let mut result = Vec::new();
+
+        if self.is_empty() {
+            return result;
+        }
+
+        // Collect breakpoints
+        let mut breakpoints = HashSet::new();
+        for connection in self {
+            breakpoints.insert(connection.this.msb + 1);
+            breakpoints.insert(connection.this.lsb);
+        }
+
+        assert!(breakpoints.len() > 1);
+
+        // Sort ascending
+        let mut breakpoints: Vec<usize> = breakpoints.into_iter().collect();
+        breakpoints.sort();
+
+        for i in 0..breakpoints.len() - 1 {
+            let msb = breakpoints[i + 1] - 1;
+            let lsb = breakpoints[i];
+            result.push(self.slice(msb, lsb));
+        }
+
+        result
+    }
+
+    pub fn extend(&mut self, other: PortSliceConnections) {
+        self.connections.extend(other.connections);
+    }
+
+    pub fn len(&self) -> usize {
+        self.connections.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.connections.is_empty()
+    }
+}
+
+impl PortSliceConnection {
+    /// Traces all directly or indirectly connected `PortSlice` reachable from
+    /// this connection's `other` slice.
+    pub fn trace(&self) -> PortSliceConnections {
+        self.trace_helper(self.this.clone())
+    }
+
+    /// Helper function for trace() that keeps track of the position with
+    /// respect to the original port through recursive calls.
+    fn trace_helper(&self, origin: PortSlice) -> PortSliceConnections {
+        let mut result = PortSliceConnections::new();
+
+        // When tracing all port connections are with respect to the original port,
+        // which is why we keep track of "origin" in the helper function.
+        result.add(origin.clone(), self.other.clone());
+
+        // Recursively trace PortSlice connections
+        if let ConnectedItem::PortSlice(port_slice) = &self.other {
+            for next in &port_slice
+                .port
+                .get_port_connections()
+                .borrow()
+                .slice(port_slice.msb, port_slice.lsb)
+            {
+                if let ConnectedItem::PortSlice(next_other) = &next.other {
+                    if next_other == &self.this {
+                        // don't trace backwards
+                        continue;
+                    }
+                }
+
+                let offset = next.this.lsb - port_slice.lsb;
+                let width = next.this.msb - next.this.lsb + 1;
+
+                let origin = origin.slice_with_offset_and_width(offset, width);
+
+                result.extend(next.trace_helper(origin));
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        connection::connected_item::{ConnectedItem, Tieoff, Wire},
+        connection::port_slice::PortSliceConnections,
+        ModDef, IO,
+    };
+
+    // Deterministic order for PortSliceConnections for the purpose of test
+    // comparisons.
+    fn sort_for_test(port_slice_connections: &mut PortSliceConnections) {
+        port_slice_connections.connections.sort_by_key(|a| {
+            (
+                a.this.get_inst_name().unwrap_or_default(),
+                a.this.port.name().to_string(),
+                a.this.msb,
+                a.this.lsb,
+                format!("{:?}", a.other),
+            )
+        });
+    }
+
+    #[test]
+    fn test_slice() {
+        let m = ModDef::new("M");
+        let a = m.add_port("a", IO::Output(12));
+        let b = m.add_port("b", IO::Input(16));
+
+        a.slice(7, 4).connect(&b.slice(15, 12));
+        a.slice(3, 0).connect(&b.slice(7, 4));
+        a.slice(11, 8).connect(&b.slice(3, 0));
+
+        let mut overlaps = a.get_port_connections().borrow().slice(5, 2);
+        sort_for_test(&mut overlaps);
+
+        assert_eq!(overlaps.len(), 2);
+        assert_eq!(overlaps[0].this, a.slice(3, 2));
+        assert_eq!(overlaps[0].other, b.slice(7, 6));
+        assert_eq!(overlaps[1].this, a.slice(5, 4));
+        assert_eq!(overlaps[1].other, b.slice(13, 12));
+
+        let empty = a.get_port_connections().borrow().slice(13, 12);
+        assert_eq!(empty.len(), 0);
+
+        let edge = a.get_port_connections().borrow().slice(8, 8);
+        assert_eq!(edge.len(), 1);
+        assert_eq!(edge[0].this, a.bit(8));
+        assert_eq!(edge[0].other, b.bit(0));
+    }
+
+    #[test]
+    fn test_trace() {
+        let a = ModDef::new("A");
+        a.add_port("x", IO::InOut(8));
+        let top = ModDef::new("Top");
+        let y = top.add_port("y", IO::InOut(8));
+
+        let a0 = top.instantiate(&a, Some("a0"), None);
+        let a1 = top.instantiate(&a, Some("a1"), None);
+
+        a0.get_port("x").connect(&y);
+        y.connect(&a1.get_port("x"));
+
+        let mut traced = a0
+            .get_port("x")
+            .get_port_connections()
+            .borrow()
+            .slice(5, 2)
+            .trace();
+        sort_for_test(&mut traced);
+
+        assert_eq!(traced.len(), 2);
+        assert_eq!(traced[0].this, a0.get_port("x").slice(5, 2));
+        assert_eq!(traced[0].other, a1.get_port("x").slice(5, 2));
+        assert_eq!(traced[1].this, a0.get_port("x").slice(5, 2));
+        assert_eq!(traced[1].other, y.slice(5, 2));
+    }
+
+    #[test]
+    fn test_trace_complex() {
+        let a = ModDef::new("A");
+        a.add_port("o", IO::Output(6));
+        let b = ModDef::new("B");
+        b.add_port("i", IO::Input(6));
+        let c = ModDef::new("C");
+        c.add_port("i", IO::Input(6));
+        let d = ModDef::new("D");
+        d.add_port("i", IO::Input(6));
+
+        let top = ModDef::new("Top");
+        let a_i = top.instantiate(&a, Some("A"), None);
+        let b_i = top.instantiate(&b, Some("B"), None);
+        let c_i = top.instantiate(&c, Some("C"), None);
+        let d_i = top.instantiate(&d, Some("D"), None);
+
+        a_i.get_port("o")
+            .slice(4, 3)
+            .connect(&b_i.get_port("i").slice(3, 2));
+        a_i.get_port("o")
+            .slice(4, 4)
+            .connect(&c_i.get_port("i").slice(5, 5));
+        a_i.get_port("o")
+            .slice(3, 3)
+            .connect(&d_i.get_port("i").slice(0, 0));
+
+        let mut traced = b_i
+            .get_port("i")
+            .get_port_connections()
+            .borrow()
+            .slice(3, 2)
+            .trace();
+        sort_for_test(&mut traced);
+
+        assert_eq!(traced.len(), 3);
+
+        assert_eq!(traced[0].this, b_i.get_port("i").slice(2, 2));
+        assert_eq!(traced[0].other, d_i.get_port("i").slice(0, 0));
+
+        assert_eq!(traced[1].this, b_i.get_port("i").slice(3, 2));
+        assert_eq!(traced[1].other, a_i.get_port("o").slice(4, 3));
+
+        assert_eq!(traced[2].this, b_i.get_port("i").slice(3, 3));
+        assert_eq!(traced[2].other, c_i.get_port("i").slice(5, 5));
+    }
+
+    #[test]
+    fn test_tieoff_clipping_slice() {
+        let m = ModDef::new("M");
+        let p = m.add_port("p", IO::Input(8));
+        p.tieoff(0xaau32);
+
+        let overlaps = p.get_port_connections().borrow().slice(6, 1);
+        assert_eq!(overlaps.len(), 1);
+        assert_eq!(overlaps[0].this, p.slice(6, 1));
+        assert_eq!(
+            overlaps[0].other,
+            ConnectedItem::Tieoff(Tieoff::new(0x15u32))
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unused_not_allowed_on_output_to_resolve() {
+        let m = ModDef::new("M");
+        let q = m.add_port("q", IO::Output(4));
+        q.unused();
+        let segments = q.get_port_connections().borrow().make_non_overlapping();
+        // resolve should panic for Output with Unused
+        let _ = segments[0].to_expression_source();
+    }
+
+    #[test]
+    fn test_tieoff_as_driver_input() {
+        let a = ModDef::new("A");
+        a.add_port("i", IO::Input(2));
+
+        let top = ModDef::new("Top");
+        let ai = top.instantiate(&a, Some("ai"), None);
+        ai.get_port("i").tieoff(0b10u32);
+
+        let segments = ai
+            .get_port("i")
+            .get_port_connections()
+            .borrow()
+            .make_non_overlapping();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0][0].this, ai.get_port("i").slice(1, 0));
+        assert_eq!(
+            segments[0].to_expression_source(),
+            Some(ConnectedItem::Tieoff(Tieoff::new(0b10u32))),
+        );
+    }
+
+    #[test]
+    fn test_unused_inout_only_alone() {
+        let m = ModDef::new("M");
+        let y = m.add_port("y", IO::InOut(2));
+        y.unused();
+        let segments = y.get_port_connections().borrow().make_non_overlapping();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0][0].this, y.slice(1, 0));
+        assert_eq!(
+            segments[0].to_expression_source(),
+            Some(ConnectedItem::Unused)
+        );
+    }
+
+    #[test]
+    fn test_wire_specify_net_name() {
+        let a_mod_def = ModDef::new("A");
+        a_mod_def.add_port("a_io", IO::InOut(8));
+        let b_mod_def = ModDef::new("B");
+        b_mod_def.add_port("b_io", IO::InOut(8));
+        let top = ModDef::new("TopModule");
+        let a_inst = top.instantiate(&a_mod_def, None, None);
+        let b_inst = top.instantiate(&b_mod_def, None, None);
+        a_inst.get_port("a_io").connect(&b_inst.get_port("b_io"));
+        a_inst.get_port("a_io").specify_net_name("custom");
+
+        let segments = b_inst
+            .get_port("b_io")
+            .get_port_connections()
+            .borrow()
+            .trace()
+            .make_non_overlapping();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0][0].this, b_inst.get_port("b_io").slice(7, 0));
+        assert_eq!(
+            segments[0].to_expression_source(),
+            Some(ConnectedItem::Wire(Wire {
+                name: "custom".to_string(),
+                width: 8,
+                msb: 7,
+                lsb: 0
+            }))
+        );
+    }
+
+    #[test]
+    fn test_tracing_in_detail() {
+        let a = ModDef::new("A");
+        a.add_port("o", IO::Output(4));
+        let b = ModDef::new("B");
+        b.add_port("i", IO::Input(3));
+
+        let top = ModDef::new("Top");
+        let a0 = top.instantiate(&a, Some("a0"), None);
+        let b0 = top.instantiate(&b, Some("b0"), None);
+        let b1 = top.instantiate(&b, Some("b1"), None);
+
+        top.add_port("in", IO::Input(1));
+        top.add_port("out", IO::Output(2));
+        top.get_port("in").connect(&top.get_port("out").bit(1));
+        a0.get_port("o").bit(3).connect(&top.get_port("out").bit(0));
+        b0.get_port("i").connect(&a0.get_port("o").slice(3, 1));
+        b1.get_port("i").connect(&a0.get_port("o").slice(2, 0));
+
+        let expected = vec![
+            (
+                a0.get_port("o"),
+                vec![
+                    (
+                        (0, 0),
+                        vec![b1.get_port("i").bit(0)],
+                        a0.get_port("o").bit(0),
+                    ),
+                    (
+                        (2, 1),
+                        vec![b0.get_port("i").slice(1, 0), b1.get_port("i").slice(2, 1)],
+                        a0.get_port("o").slice(2, 1),
+                    ),
+                    (
+                        (3, 3),
+                        vec![b0.get_port("i").bit(2), top.get_port("out").bit(0)],
+                        top.get_port("out").bit(0),
+                    ),
+                ],
+            ),
+            (
+                b0.get_port("i"),
+                vec![
+                    (
+                        (1, 0),
+                        vec![a0.get_port("o").slice(2, 1), b1.get_port("i").slice(2, 1)],
+                        a0.get_port("o").slice(2, 1),
+                    ),
+                    (
+                        (2, 2),
+                        vec![a0.get_port("o").bit(3), top.get_port("out").bit(0)],
+                        top.get_port("out").bit(0),
+                    ),
+                ],
+            ),
+            (
+                b1.get_port("i"),
+                vec![
+                    (
+                        (0, 0),
+                        vec![a0.get_port("o").bit(0)],
+                        a0.get_port("o").bit(0),
+                    ),
+                    (
+                        (2, 1),
+                        vec![a0.get_port("o").slice(2, 1), b0.get_port("i").slice(1, 0)],
+                        a0.get_port("o").slice(2, 1),
+                    ),
+                ],
+            ),
+            (
+                top.get_port("out"),
+                vec![
+                    (
+                        (0, 0),
+                        vec![a0.get_port("o").bit(3), b0.get_port("i").bit(2)],
+                        top.get_port("out").bit(0),
+                    ),
+                    (
+                        (1, 1),
+                        vec![top.get_port("in").bit(0)],
+                        top.get_port("in").bit(0),
+                    ),
+                ],
+            ),
+        ];
+
+        for (port, segments) in expected {
+            let mut non_overlapping = port
+                .get_port_connections()
+                .borrow()
+                .trace()
+                .make_non_overlapping();
+            assert_eq!(non_overlapping.len(), segments.len());
+            for (expected, actual_connections) in segments.iter().zip(non_overlapping.iter_mut()) {
+                let ((expected_msb, expected_lsb), expected_connections, expected_name_source) =
+                    expected;
+                assert_eq!(actual_connections.len(), expected_connections.len());
+                assert_eq!(
+                    actual_connections.to_expression_source().unwrap(),
+                    *expected_name_source
+                );
+                sort_for_test(actual_connections);
+                for (actual_connection, expected_connection) in actual_connections
+                    .into_iter()
+                    .zip(expected_connections.iter())
+                {
+                    assert_eq!(
+                        actual_connection.this,
+                        port.slice(*expected_msb as usize, *expected_lsb as usize)
+                    );
+                    assert_eq!(actual_connection.other, *expected_connection);
+                }
+            }
+        }
+    }
+}

--- a/src/funnel.rs
+++ b/src/funnel.rs
@@ -124,10 +124,10 @@ impl Funnel {
                     self.a_in_offset + a.width() - self.a_in.width()
                 );
                 self.a_in
-                    .slice_relative(self.a_in_offset, a.width())
+                    .slice_with_offset_and_width(self.a_in_offset, a.width())
                     .connect(&a);
                 self.b_out
-                    .slice_relative(self.a_in_offset, b.width())
+                    .slice_with_offset_and_width(self.a_in_offset, b.width())
                     .connect(&b);
                 self.a_in_offset += a.width();
             }
@@ -142,10 +142,10 @@ impl Funnel {
                 self.a_out_offset + a.width() - self.a_out.width()
             );
             self.a_out
-                .slice_relative(self.a_out_offset, a.width())
+                .slice_with_offset_and_width(self.a_out_offset, a.width())
                 .connect(&a);
             self.b_in
-                .slice_relative(self.a_out_offset, b.width())
+                .slice_with_offset_and_width(self.a_out_offset, b.width())
                 .connect(&b);
             self.a_out_offset += a.width();
         } else {
@@ -254,12 +254,14 @@ impl Funnel {
     /// "b" output port slice. If there are no remaining bits, returns None.
     pub fn a2b_yield_remaining(&mut self) -> Option<(PortSlice, PortSlice)> {
         if self.a_in_offset < self.a_in.width() {
-            let a_in_slice = self
-                .a_in
-                .slice_relative(self.a_in_offset, self.a_in.width() - self.a_in_offset);
-            let b_out_slice = self
-                .b_out
-                .slice_relative(self.a_in_offset, self.b_out.width() - self.a_in_offset);
+            let a_in_slice = self.a_in.slice_with_offset_and_width(
+                self.a_in_offset,
+                self.a_in.width() - self.a_in_offset,
+            );
+            let b_out_slice = self.b_out.slice_with_offset_and_width(
+                self.a_in_offset,
+                self.b_out.width() - self.a_in_offset,
+            );
             self.a_in_offset = self.a_in.width();
             Some((a_in_slice, b_out_slice))
         } else {
@@ -272,12 +274,14 @@ impl Funnel {
     /// "a" output port slice. If there are no remaining bits, returns None.
     pub fn b2a_yield_remaining(&mut self) -> Option<(PortSlice, PortSlice)> {
         if self.a_out_offset < self.a_out.width() {
-            let b_in_slice = self
-                .b_in
-                .slice_relative(self.a_out_offset, self.b_in.width() - self.a_out_offset);
-            let a_out_slice = self
-                .a_out
-                .slice_relative(self.a_out_offset, self.a_out.width() - self.a_out_offset);
+            let b_in_slice = self.b_in.slice_with_offset_and_width(
+                self.a_out_offset,
+                self.b_in.width() - self.a_out_offset,
+            );
+            let a_out_slice = self.a_out.slice_with_offset_and_width(
+                self.a_out_offset,
+                self.a_out.width() - self.a_out_offset,
+            );
             self.a_out_offset = self.a_out.width();
             Some((b_in_slice, a_out_slice))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use port::Port;
 mod port_slice;
 pub use port_slice::{ConvertibleToPortSlice, PortSlice};
 
+mod connection;
 mod mod_def;
 use mod_def::ModDefCore;
 pub use mod_def::ParameterType;

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -109,6 +109,8 @@ impl ModDef {
                 whole_port_unused: IndexMap::new(),
                 verilog_import: None,
                 inst_connections: IndexMap::new(),
+                mod_inst_arcs: IndexMap::new(),
+                mod_def_arcs: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -10,6 +10,7 @@ use num_bigint::BigInt;
 use crate::mod_def::dtypes::{PhysicalPin, VerilogImport};
 use crate::mod_def::tracks::{TrackDefinitions, TrackOccupancies};
 
+use crate::connection::PortSliceConnections;
 pub(crate) use crate::mod_def::{Assignment, InstConnection, Wire};
 use crate::{PortSlice, Usage, IO};
 
@@ -34,6 +35,8 @@ pub struct ModDefCore {
     pub(crate) whole_port_tieoffs: IndexMap<String, IndexMap<String, BigInt>>,
     pub(crate) whole_port_unused: IndexMap<String, HashSet<String>>,
     pub(crate) inst_connections: IndexMap<String, IndexMap<String, Vec<InstConnection>>>,
+    pub(crate) mod_inst_arcs: IndexMap<String, IndexMap<String, Rc<RefCell<PortSliceConnections>>>>,
+    pub(crate) mod_def_arcs: IndexMap<String, Rc<RefCell<PortSliceConnections>>>,
     pub(crate) reserved_net_definitions: IndexMap<String, Wire>,
     pub(crate) enum_ports: IndexMap<String, String>,
     pub(crate) adjacency_matrix: HashMap<String, HashSet<String>>,

--- a/src/mod_def/emit.rs
+++ b/src/mod_def/emit.rs
@@ -158,7 +158,7 @@ impl ModDef {
                 let net_name = format!("{inst_name}_{port_name}");
                 if ports.contains_key(&net_name) {
                     panic!("Generated net name for instance port {}.{} collides with a port name on module definition {}: \
-both are called {}. Altering the instance name will likely fix this problem. connect_to_net() could also be used to \
+both are called {}. Altering the instance name will likely fix this problem. specify_net_name() could also be used to \
 specify an alternate net name for this instance port, although that may be more labor-intensive since all connectivity \
 on that net will need to be updated.",
                         inst_name, port_name, core.name, net_name
@@ -170,7 +170,7 @@ on that net will need to be updated.",
                     .is_some()
                 {
                     panic!("Generated net name for instance port {}.{} collides with another generated net name within \
-module definition {}: both are called {}. Altering the instance name will likely fix this problem. connect_to_net() could \
+module definition {}: both are called {}. Altering the instance name will likely fix this problem. specify_net_name() could \
 also be used to specify an alternate net name for this instance port, although that may be more labor-intensive since all \
 connectivity on that net will need to be updated.",
                         inst_name, port_name, core.name, net_name);
@@ -202,10 +202,10 @@ connectivity on that net will need to be updated.",
                 )
                 .is_some()
             {
-                panic!("connect_to_net()-specified net name {} already exists in module definition {}. \
+                panic!("net name {} from specify_net_name() already exists in module definition {}. \
 This is likely due to a collision with a generated net name, which has the form {{instance name}}_{{port name}}. \
 Two possible solutions: 1) change the instance name corresponding to the generated net name, or 2) provide an \
-alternate net name to connect_to_net().",
+alternate net name to specify_net_name().",
                     wire.name, core.name
                 );
             }

--- a/src/mod_def/parameterize.rs
+++ b/src/mod_def/parameterize.rs
@@ -292,6 +292,8 @@ impl ModDef {
                 whole_port_unused: IndexMap::new(),
                 verilog_import: None,
                 inst_connections: IndexMap::new(),
+                mod_inst_arcs: IndexMap::new(),
+                mod_def_arcs: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -122,6 +122,8 @@ impl ModDef {
                     ignore_unknown_modules: cfg.ignore_unknown_modules,
                 }),
                 inst_connections: IndexMap::new(),
+                mod_inst_arcs: IndexMap::new(),
+                mod_def_arcs: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),

--- a/src/mod_def/pins.rs
+++ b/src/mod_def/pins.rs
@@ -312,6 +312,8 @@ impl ModDef {
             whole_port_tieoffs: IndexMap::new(),
             whole_port_unused: IndexMap::new(),
             inst_connections: IndexMap::new(),
+            mod_inst_arcs: IndexMap::new(),
+            mod_def_arcs: IndexMap::new(),
             reserved_net_definitions: core.reserved_net_definitions.clone(),
             enum_ports: IndexMap::new(),
             adjacency_matrix: HashMap::new(),

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -35,6 +35,8 @@ impl ModDef {
                 whole_port_unused: IndexMap::new(),
                 verilog_import: None,
                 inst_connections: IndexMap::new(),
+                mod_inst_arcs: IndexMap::new(),
+                mod_def_arcs: IndexMap::new(),
                 reserved_net_definitions: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
                 ignore_adjacency: HashSet::new(),

--- a/src/mod_inst.rs
+++ b/src/mod_inst.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::hash::{Hash, Hasher};
+
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
@@ -12,6 +14,29 @@ use crate::{Coordinate, Mat3, Orientation, Placement, Polygon};
 pub struct HierPathElem {
     pub(crate) mod_def_core: Weak<RefCell<ModDefCore>>,
     pub(crate) inst_name: String,
+}
+
+impl PartialEq for HierPathElem {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.mod_def_core.upgrade(), other.mod_def_core.upgrade()) {
+            (Some(a_rc), Some(b_rc)) => {
+                Rc::ptr_eq(&a_rc, &b_rc) && (self.inst_name == other.inst_name)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Hash for HierPathElem {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.mod_def_core
+            .upgrade()
+            .unwrap()
+            .borrow()
+            .name
+            .hash(state);
+        self.inst_name.hash(state);
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/port/connect.rs
+++ b/src/port/connect.rs
@@ -4,8 +4,8 @@ use crate::{ConvertibleToPortSlice, ModInst, PipelineConfig, Port};
 
 impl Port {
     /// Connects this port to a net with a specific name.
-    pub fn connect_to_net(&self, net: &str) {
-        self.to_port_slice().connect_to_net(net);
+    pub fn specify_net_name(&self, net: &str) {
+        self.to_port_slice().specify_net_name(net);
     }
 
     /// Connects this port to another port or port slice.

--- a/src/port_slice.rs
+++ b/src/port_slice.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
+use std::fmt::{self, Debug};
 use std::rc::Rc;
 
 use crate::{Coordinate, EdgeOrientation, Mat3, ModDef, ModDefCore, PhysicalPin, Port};
@@ -15,11 +16,17 @@ mod tieoff;
 /// A slice is a defined as a contiguous range of bits from `msb` down to `lsb`,
 /// inclusive. A slice can be a single bit on the port (`msb` equal to `lsb`),
 /// the entire port, or any range in between.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PortSlice {
     pub(crate) port: Port,
     pub(crate) msb: usize,
     pub(crate) lsb: usize,
+}
+
+impl Debug for PortSlice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.debug_string())
+    }
 }
 
 impl PortSlice {
@@ -176,7 +183,7 @@ impl PortSlice {
             .collect()
     }
 
-    pub(crate) fn slice_relative(&self, offset: usize, width: usize) -> Self {
+    pub(crate) fn slice_with_offset_and_width(&self, offset: usize, width: usize) -> Self {
         assert!(offset + width <= self.width());
 
         PortSlice {

--- a/src/port_slice/tieoff.rs
+++ b/src/port_slice/tieoff.rs
@@ -2,6 +2,8 @@
 
 use num_bigint::BigInt;
 
+use crate::connection::connected_item::{ConnectedItem, Tieoff};
+use crate::port_slice::ConvertibleToPortSlice;
 use crate::{Port, PortSlice};
 
 impl PortSlice {
@@ -31,9 +33,15 @@ impl PortSlice {
                     .whole_port_tieoffs
                     .entry(inst_name)
                     .or_default()
-                    .insert(port_name, big_int_value);
+                    .insert(port_name, big_int_value.clone());
             }
         }
+
+        // TODO: work in progress - part of connection refactoring
+        self.port
+            .get_port_connections()
+            .borrow_mut()
+            .add(self.to_port_slice(), Tieoff::new(big_int_value));
     }
 
     /// Marks this port slice as unused, meaning that if it is an module
@@ -61,5 +69,11 @@ impl PortSlice {
                     .insert(port_name);
             }
         }
+
+        // TODO: work in progress - part of connection refactoring
+        self.port
+            .get_port_connections()
+            .borrow_mut()
+            .add(self.to_port_slice(), ConnectedItem::Unused);
     }
 }

--- a/tests/connections/net.rs
+++ b/tests/connections/net.rs
@@ -3,7 +3,7 @@
 use topstitch::*;
 
 #[test]
-fn test_connect_to_net() {
+fn test_specify_net_name() {
     let a_verilog = "\
 module A(
   output [7:0] ao
@@ -19,8 +19,8 @@ endmodule";
     let top = ModDef::new("TopModule");
     let a_inst = top.instantiate(&a_mod_def, None, None);
     let b_inst = top.instantiate(&b_mod_def, None, None);
-    a_inst.get_port("ao").connect_to_net("custom");
-    b_inst.get_port("bi").connect_to_net("custom");
+    a_inst.get_port("ao").specify_net_name("custom");
+    b_inst.get_port("bi").specify_net_name("custom");
     assert_eq!(
         top.emit(true),
         "\
@@ -38,7 +38,7 @@ endmodule
 }
 
 #[test]
-fn test_connect_to_net_multiple_receivers() {
+fn test_specify_net_name_multiple_receivers() {
     let a_verilog = "\
 module A(
   output [7:0] ao
@@ -55,9 +55,9 @@ endmodule";
     let a_inst = top.instantiate(&a_mod_def, None, None);
     let b_inst_0 = top.instantiate(&b_mod_def, Some("B_i_0"), None);
     let b_inst_1 = top.instantiate(&b_mod_def, Some("B_i_1"), None);
-    a_inst.get_port("ao").connect_to_net("custom");
-    b_inst_0.get_port("bi").connect_to_net("custom");
-    b_inst_1.get_port("bi").connect_to_net("custom");
+    a_inst.get_port("ao").specify_net_name("custom");
+    b_inst_0.get_port("bi").specify_net_name("custom");
+    b_inst_1.get_port("bi").specify_net_name("custom");
     assert_eq!(
         top.emit(true),
         "\
@@ -78,7 +78,7 @@ endmodule
 }
 
 #[test]
-fn test_connect_to_net_with_slice() {
+fn test_specify_net_name_with_slice() {
     let a_verilog = "\
 module A(
   output [7:0] a
@@ -95,10 +95,10 @@ endmodule";
     let top = ModDef::new("TopModule");
     let a_inst = top.instantiate(&a_mod_def, None, None);
     let b_inst = top.instantiate(&b_mod_def, Some("B_i_0"), None);
-    a_inst.get_port("a").slice(3, 0).connect_to_net("custom0");
-    a_inst.get_port("a").slice(7, 4).connect_to_net("custom1");
-    b_inst.get_port("b0").connect_to_net("custom0");
-    b_inst.get_port("b1").connect_to_net("custom1");
+    a_inst.get_port("a").slice(3, 0).specify_net_name("custom0");
+    a_inst.get_port("a").slice(7, 4).specify_net_name("custom1");
+    b_inst.get_port("b0").specify_net_name("custom0");
+    b_inst.get_port("b1").specify_net_name("custom1");
     assert_eq!(
         top.emit(true),
         "\
@@ -119,7 +119,7 @@ endmodule
 
 #[test]
 #[should_panic(expected = "TopModule.B_i.bi (ModInst Input) is undriven")]
-fn test_connect_to_net_undriven_input() {
+fn test_specify_net_name_undriven_input() {
     let a_verilog = "\
 module A(
   output ao
@@ -135,13 +135,13 @@ endmodule";
     let top = ModDef::new("TopModule");
     let a_inst = top.instantiate(&a_mod_def, None, None);
     top.instantiate(&b_mod_def, None, None);
-    a_inst.get_port("ao").connect_to_net("custom");
+    a_inst.get_port("ao").specify_net_name("custom");
     top.validate();
 }
 
 #[test]
 #[should_panic(expected = "TopModule.A_i.ao (ModInst Output) is unused")]
-fn test_connect_to_net_unused_output() {
+fn test_specify_net_name_unused_output() {
     let a_verilog = "\
 module A(
   output ao
@@ -157,13 +157,13 @@ endmodule";
     let top = ModDef::new("TopModule");
     top.instantiate(&a_mod_def, None, None);
     let b_inst = top.instantiate(&b_mod_def, None, None);
-    b_inst.get_port("bi").connect_to_net("custom");
+    b_inst.get_port("bi").specify_net_name("custom");
     top.validate();
 }
 
 #[test]
 #[should_panic(expected = "Net width mismatch for TopModule.custom: existing width 4, new width 8")]
-fn test_connect_to_net_width_mismatch() {
+fn test_specify_net_name_width_mismatch() {
     let a_verilog = "\
 module A(
   output [3:0] ao
@@ -179,7 +179,7 @@ endmodule";
     let top = ModDef::new("TopModule");
     let a_inst = top.instantiate(&a_mod_def, None, None);
     let b_inst = top.instantiate(&b_mod_def, None, None);
-    a_inst.get_port("ao").connect_to_net("custom");
-    b_inst.get_port("bi").connect_to_net("custom");
+    a_inst.get_port("ao").specify_net_name("custom");
+    b_inst.get_port("bi").specify_net_name("custom");
     top.validate();
 }


### PR DESCRIPTION
First step in an overhaul of the representation of connections in TopStitch.

Eventual goals are:
1. Emit netlists that avoid `assign` statements unless truly necessary (e.g., direct connection between `ModDef` `Input` and `Output`)
2. Make it possible to trace connections between module instances for the purpose of pin location derivation.
3. Make it possible to move instances hierarchically with connections following automatically.
4. Avoid special cases for `InOut` connections, wire name specifications, whole-port tieoffs and unused markers, etc. to make the codebase easier to maintain and extend.

In this first step, new data structures and algorithms for representing connectivity are brought up in parallel to the existing representation of connectivity. This means that most existing tests do not need to be modified, because the TopStitch netlist output is unchanged.

The new scheme for representing connections is to have hash maps in `ModDefCore` that store a `PortSliceConnections` struct for each `ModDef` and `ModInst` `Port`, which will replace the current flat list of connection pairs, in a future PR. This new structure makes it easier and more efficient to look up connections associated with a particular `Port` or `PortSlice`.

As connections are made (to other ports/port slices, to tieoffs, to "unused" markers, to wire name specifications), this information is recorded in the `PortSliceConnections` structs. Connections to other ports/port slices are recorded as bidirectional edges, allowing the connectivity graph to be traversed.

Finally, functions are provided that allow `PortSliceConnections` to be resolved into non-overlapping segments, each of which can be reduced to a single, deterministic "expression source" that will be used in setting wire names during Verilog generation (to be implemented in a follow-up PR)

Note: in most use cases, connections are expected to be "simple": one `Port` connects to another `Port`. The new graph structure becomes more important in more complex situations, e.g.:
1. `ModInst` `Output` fans out to some instance inputs and a `ModDef` `Output` (in which case the `ModDef` `Output` should be used as the name source to avoid declaring unnecessary wires)
2. A wire name specification is attached to a `ModInst` `Port` - we want this specification to propagate to connected ports.
3. Multiple `InOut`s are connected together
4. Overlapping slices of a `Port` are connected to various places.
