### PR TITLE
Updates to parameters and pipelining

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -16,7 +16,7 @@ fn main() {
         true,
         false,
     );
-    let adder_9_bit = adder_8_bit.parameterize(&[("W", 9)], None, None);
+    let adder_9_bit = adder_8_bit.parameterize(&[("W", 9)]);
 
     // Create a top-level module definition
 

--- a/examples/stub.rs
+++ b/examples/stub.rs
@@ -20,7 +20,7 @@ fn main() {
     // Parameterization is optional; it's shown here to illustrate the feature. The
     // parameterize() function returns a new ModDef with the given parameter values.
     // Unspecified parameters will use their default values.
-    let block_parameterized = block.parameterize(&[("N", 32)], None, None);
+    let block_parameterized = block.parameterize(&[("N", 32)]);
 
     // Create a stub for the parameterized block. Try replacing
     // "block_parameterized" with "block" - it will still work, using default

--- a/src/intf/connect.rs
+++ b/src/intf/connect.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::connection::port_slice::Abutment;
 use crate::{Intf, ModInst, PipelineConfig};
 
 impl Intf {
@@ -16,24 +17,24 @@ impl Intf {
     /// other interface did not, this method would panic unless `allow_mismatch`
     /// was `true`.
     pub fn connect(&self, other: &Intf, allow_mismatch: bool) {
-        self.connect_generic(other, None, false, allow_mismatch);
+        self.connect_generic(other, None, Abutment::Abutted, allow_mismatch);
     }
 
     /// Connects this interface to another interface, assuming that the
     /// connection is non-abutted.
     pub fn connect_non_abutted(&self, other: &Intf, allow_mismatch: bool) {
-        self.connect_generic(other, None, true, allow_mismatch);
+        self.connect_generic(other, None, Abutment::NonAbutted, allow_mismatch);
     }
 
     pub fn connect_pipeline(&self, other: &Intf, pipeline: PipelineConfig, allow_mismatch: bool) {
-        self.connect_generic(other, Some(pipeline), false, allow_mismatch);
+        self.connect_generic(other, Some(pipeline), Abutment::NA, allow_mismatch);
     }
 
     pub(crate) fn connect_generic(
         &self,
         other: &Intf,
         pipeline: Option<PipelineConfig>,
-        is_non_abutted: bool,
+        abutment: Abutment,
         allow_mismatch: bool,
     ) {
         let self_ports = self.get_port_slices();
@@ -41,7 +42,7 @@ impl Intf {
 
         for (func_name, self_port) in &self_ports {
             if let Some(other_port) = other_ports.get(func_name) {
-                self_port.connect_generic(other_port, pipeline.clone(), is_non_abutted);
+                self_port.connect_generic(other_port, pipeline.clone(), abutment.clone());
             } else if !allow_mismatch {
                 panic!(
                     "Interfaces {} and {} have mismatched functions and allow_mismatch is false. Example: function '{}' is present in {} but not in {}.",

--- a/src/intf/crossover.rs
+++ b/src/intf/crossover.rs
@@ -3,6 +3,7 @@
 use indexmap::IndexMap;
 use regex::Regex;
 
+use crate::connection::port_slice::Abutment;
 use crate::util::concat_captures;
 use crate::{Intf, ModInst, PipelineConfig};
 
@@ -57,7 +58,11 @@ impl Intf {
             x_port_slices[&x_func_name].connect_generic(
                 &y_port_slices[&y_func_name],
                 pipeline.clone(),
-                is_non_abutted,
+                if is_non_abutted {
+                    Abutment::NonAbutted
+                } else {
+                    Abutment::Abutted
+                },
             );
         }
     }

--- a/src/mod_def.rs
+++ b/src/mod_def.rs
@@ -24,7 +24,7 @@ mod instances;
 mod intf;
 mod parameterize;
 mod placement;
-pub use parameterize::ParameterType;
+pub use parameterize::{ParameterSpec, ParameterType};
 pub use placement::CalculatedPlacement;
 mod lefdef;
 mod parser;
@@ -100,8 +100,8 @@ impl ModDef {
                 interfaces: IndexMap::new(),
                 instances: IndexMap::new(),
                 usage: Default::default(),
-                generated_verilog: None,
                 verilog_import: None,
+                parameters: IndexMap::new(),
                 mod_inst_connections: IndexMap::new(),
                 mod_def_connections: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
@@ -113,13 +113,13 @@ impl ModDef {
                 track_definitions: None,
                 track_occupancies: None,
                 specified_net_names: HashSet::new(),
+                pipeline_counter: 0..,
             })),
         }
     }
 
     fn frozen(&self) -> bool {
-        self.core.borrow().generated_verilog.is_some()
-            || self.core.borrow().verilog_import.is_some()
+        self.core.borrow().verilog_import.is_some()
     }
 
     /// Returns the name of this module definition.
@@ -130,12 +130,6 @@ impl ModDef {
     /// Configures how this module definition should be used when validating
     /// and/or emitting Verilog.
     pub fn set_usage(&self, usage: Usage) {
-        if self.core.borrow().generated_verilog.is_some() {
-            assert!(
-                usage != Usage::EmitDefinitionAndDescend,
-                "Cannot descend into a module defined from Verilog sources."
-            );
-        }
         self.core.borrow_mut().usage = usage;
     }
 

--- a/src/mod_def/core.rs
+++ b/src/mod_def/core.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::ops::RangeFrom;
 use std::rc::Rc;
 
 use indexmap::IndexMap;
@@ -25,8 +26,9 @@ pub struct ModDefCore {
     pub(crate) interfaces: IndexMap<String, IndexMap<String, (String, usize, usize)>>,
     pub(crate) instances: IndexMap<String, Rc<RefCell<ModDefCore>>>,
     pub(crate) usage: Usage,
-    pub(crate) generated_verilog: Option<String>,
     pub(crate) verilog_import: Option<VerilogImport>,
+    /// Parameter overrides applied to this module definition (by name)
+    pub(crate) parameters: IndexMap<String, crate::mod_def::ParameterSpec>,
     pub(crate) mod_inst_connections:
         IndexMap<String, IndexMap<String, Rc<RefCell<PortSliceConnections>>>>,
     pub(crate) mod_def_connections: IndexMap<String, Rc<RefCell<PortSliceConnections>>>,
@@ -43,6 +45,8 @@ pub struct ModDefCore {
     /// this module definition. Used to detect duplicate specifications and to
     /// check for name collisions during emission.
     pub(crate) specified_net_names: HashSet<String>,
+    /// Internal counter to generate unique pipeline instance names
+    pub(crate) pipeline_counter: RangeFrom<usize>,
 }
 
 impl ModDefCore {

--- a/src/mod_def/dtypes.rs
+++ b/src/mod_def/dtypes.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::mod_def::tracks::{TrackDefinition, TrackOrientation};
+#[derive(Clone)]
 pub(crate) struct VerilogImport {
     pub(crate) sources: Vec<String>,
     pub(crate) incdirs: Vec<String>,

--- a/src/mod_def/feedthrough.rs
+++ b/src/mod_def/feedthrough.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::connection::port_slice::Abutment;
 use crate::{ModDef, PipelineConfig, IO};
 
 impl ModDef {
@@ -35,6 +36,6 @@ impl ModDef {
     ) {
         let input_port = self.add_port(input_name, IO::Input(width));
         let output_port = self.add_port(output_name, IO::Output(width));
-        input_port.connect_generic(&output_port, pipeline, false);
+        input_port.connect_generic(&output_port, pipeline, Abutment::NA);
     }
 }

--- a/src/mod_def/parser.rs
+++ b/src/mod_def/parser.rs
@@ -104,7 +104,6 @@ impl ModDef {
                 interfaces: IndexMap::new(),
                 instances: IndexMap::new(),
                 usage: Usage::EmitNothingAndStop,
-                generated_verilog: None,
                 verilog_import: Some(VerilogImport {
                     sources: cfg.sources.iter().map(|s| s.to_string()).collect(),
                     incdirs: cfg.incdirs.iter().map(|s| s.to_string()).collect(),
@@ -116,6 +115,7 @@ impl ModDef {
                     skip_unsupported: cfg.skip_unsupported,
                     ignore_unknown_modules: cfg.ignore_unknown_modules,
                 }),
+                parameters: IndexMap::new(),
                 mod_inst_connections: IndexMap::new(),
                 mod_def_connections: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
@@ -127,6 +127,7 @@ impl ModDef {
                 track_definitions: None,
                 track_occupancies: None,
                 specified_net_names: HashSet::new(),
+                pipeline_counter: 0..,
             })),
         }
     }

--- a/src/mod_def/pins.rs
+++ b/src/mod_def/pins.rs
@@ -304,8 +304,8 @@ impl ModDef {
             interfaces: IndexMap::new(),
             instances: IndexMap::new(),
             usage: core.usage.clone(),
-            generated_verilog: None,
             verilog_import: None,
+            parameters: IndexMap::new(),
             mod_inst_connections: IndexMap::new(),
             mod_def_connections: IndexMap::new(),
             enum_ports: IndexMap::new(),
@@ -318,6 +318,7 @@ impl ModDef {
             track_definitions: core.track_definitions.clone(),
             track_occupancies: cloned_occupancies,
             specified_net_names: HashSet::new(),
+            pipeline_counter: 0..,
         };
 
         ModDef {

--- a/src/mod_def/stub.rs
+++ b/src/mod_def/stub.rs
@@ -27,8 +27,8 @@ impl ModDef {
                 interfaces: core.interfaces.clone(),
                 instances: IndexMap::new(),
                 usage: Default::default(),
-                generated_verilog: None,
                 verilog_import: None,
+                parameters: IndexMap::new(),
                 mod_inst_connections: IndexMap::new(),
                 mod_def_connections: IndexMap::new(),
                 adjacency_matrix: HashMap::new(),
@@ -40,6 +40,7 @@ impl ModDef {
                 track_definitions: None,
                 track_occupancies: None,
                 specified_net_names: HashSet::new(),
+                pipeline_counter: 0..,
             })),
         }
     }

--- a/src/port.rs
+++ b/src/port.rs
@@ -16,6 +16,13 @@ mod export;
 mod feedthrough;
 mod tieoff;
 
+#[derive(Clone, Debug)]
+pub enum PortDirectionality {
+    Driver,
+    Receiver,
+    NA,
+}
+
 /// Represents a port on a module definition or a module instance.
 #[derive(Clone, Debug)]
 pub enum Port {
@@ -314,6 +321,21 @@ impl Port {
             Port::ModInst { port_name, .. } => {
                 default_net_name_for_inst_port(self.inst_name().unwrap(), port_name)
             }
+        }
+    }
+
+    pub(crate) fn get_directionality(&self) -> PortDirectionality {
+        match self {
+            Port::ModDef { .. } => match self.io() {
+                IO::Input(_) => PortDirectionality::Driver,
+                IO::Output(_) => PortDirectionality::Receiver,
+                IO::InOut(_) => PortDirectionality::NA,
+            },
+            Port::ModInst { .. } => match self.io() {
+                IO::Input(_) => PortDirectionality::Receiver,
+                IO::Output(_) => PortDirectionality::Driver,
+                IO::InOut(_) => PortDirectionality::NA,
+            },
         }
     }
 }

--- a/src/port/connect.rs
+++ b/src/port/connect.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::connection::port_slice::Abutment;
 use crate::{ConvertibleToPortSlice, ModInst, PipelineConfig, Port};
 
 impl Port {
@@ -10,27 +11,27 @@ impl Port {
 
     /// Connects this port to another port or port slice.
     pub fn connect<T: ConvertibleToPortSlice>(&self, other: &T) {
-        self.connect_generic(other, None, false);
+        self.connect_generic(other, None, Abutment::Abutted);
     }
 
     /// Connects this port to another port or port slice, assuming that the
     /// connection is non-abutted.
     pub fn connect_non_abutted<T: ConvertibleToPortSlice>(&self, other: &T) {
-        self.connect_generic(other, None, true);
+        self.connect_generic(other, None, Abutment::NonAbutted);
     }
 
     pub fn connect_pipeline<T: ConvertibleToPortSlice>(&self, other: &T, pipeline: PipelineConfig) {
-        self.connect_generic(other, Some(pipeline), false);
+        self.connect_generic(other, Some(pipeline), Abutment::NA);
     }
 
     pub(crate) fn connect_generic<T: ConvertibleToPortSlice>(
         &self,
         other: &T,
         pipeline: Option<PipelineConfig>,
-        is_non_abutted: bool,
+        abutment: Abutment,
     ) {
         self.to_port_slice()
-            .connect_generic(other, pipeline, is_non_abutted);
+            .connect_generic(other, pipeline, abutment);
     }
 
     /// Punches a sequence of feedthroughs through the specified module

--- a/src/port_slice.rs
+++ b/src/port_slice.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
+use crate::port::PortDirectionality;
 use crate::{Coordinate, EdgeOrientation, Mat3, ModDef, ModDefCore, PhysicalPin, Port};
 
 mod connect;
@@ -297,6 +298,10 @@ impl PortSlice {
         } else {
             None
         }
+    }
+
+    pub(crate) fn get_directionality(&self) -> PortDirectionality {
+        self.port.get_directionality()
     }
 }
 

--- a/src/port_slice/feedthrough.rs
+++ b/src/port_slice/feedthrough.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::connection::port_slice::Abutment;
 use crate::{ConvertibleToModDef, PipelineConfig, Port, PortSlice};
 
 impl PortSlice {
@@ -39,7 +40,7 @@ impl PortSlice {
         let original_port = mod_def_or_mod_inst
             .to_mod_def()
             .add_port(&original, self.port.io().with_width(self.width()));
-        flipped_port.connect_generic(&original_port, pipeline.clone(), false);
+        flipped_port.connect_generic(&original_port, pipeline.clone(), Abutment::NA);
         (
             mod_def_or_mod_inst.get_port(&flipped),
             mod_def_or_mod_inst.get_port(&original),

--- a/tests/connections/connect.rs
+++ b/tests/connections/connect.rs
@@ -221,7 +221,6 @@ endmodule
 }
 
 #[test]
-#[ignore = "skipped until the pipeline implementation is updated"]
 fn test_connect_through_generic() {
     let module_a_verilog = "
       module ModuleA (
@@ -281,8 +280,8 @@ module ModuleB(
     .NumStages(32'h0000_00ab)
   ) pipeline_conn_0 (
     .clk(clk),
-    .in(ft_flipped[7:0]),
-    .out(ft_original[7:0]),
+    .in(ft_flipped),
+    .out(ft_original),
     .out_stages()
   );
 endmodule
@@ -290,7 +289,7 @@ module ModuleC(
   input wire [7:0] ft_flipped,
   output wire [7:0] ft_original
 );
-  assign ft_original[7:0] = ft_flipped[7:0];
+  assign ft_original = ft_flipped;
 endmodule
 module ModuleD(
   input wire [7:0] ft_flipped,
@@ -302,44 +301,36 @@ module ModuleD(
     .NumStages(32'h0000_00ef)
   ) pipeline_conn_0 (
     .clk(clk),
-    .in(ft_flipped[7:0]),
-    .out(ft_original[7:0]),
+    .in(ft_flipped),
+    .out(ft_original),
     .out_stages()
   );
 endmodule
 module TopModule;
   wire [7:0] ModuleA_i_a;
-  wire [7:0] ModuleB_i_ft_flipped;
-  wire [7:0] ModuleB_i_ft_original;
-  wire [7:0] ModuleC_i_ft_flipped;
-  wire [7:0] ModuleC_i_ft_original;
-  wire [7:0] ModuleD_i_ft_flipped;
-  wire [7:0] ModuleD_i_ft_original;
-  wire [7:0] ModuleE_i_e;
   ModuleA ModuleA_i (
     .a(ModuleA_i_a)
   );
+  wire [7:0] ModuleB_i_ft_original;
   ModuleB ModuleB_i (
-    .ft_flipped(ModuleB_i_ft_flipped),
+    .ft_flipped(ModuleA_i_a),
     .ft_original(ModuleB_i_ft_original),
     .clk(1'h0)
   );
+  wire [7:0] ModuleC_i_ft_original;
   ModuleC ModuleC_i (
-    .ft_flipped(ModuleC_i_ft_flipped),
+    .ft_flipped(ModuleB_i_ft_original),
     .ft_original(ModuleC_i_ft_original)
   );
+  wire [7:0] ModuleD_i_ft_original;
   ModuleD ModuleD_i (
-    .ft_flipped(ModuleD_i_ft_flipped),
+    .ft_flipped(ModuleC_i_ft_original),
     .ft_original(ModuleD_i_ft_original),
     .clk(1'h0)
   );
   ModuleE ModuleE_i (
-    .e(ModuleE_i_e)
+    .e(ModuleD_i_ft_original)
   );
-  assign ModuleB_i_ft_flipped[7:0] = ModuleA_i_a[7:0];
-  assign ModuleC_i_ft_flipped[7:0] = ModuleB_i_ft_original[7:0];
-  assign ModuleD_i_ft_flipped[7:0] = ModuleC_i_ft_original[7:0];
-  assign ModuleE_i_e[7:0] = ModuleD_i_ft_original[7:0];
 endmodule
 "
     );

--- a/tests/feedthroughs/feedthrough.rs
+++ b/tests/feedthroughs/feedthrough.rs
@@ -139,7 +139,6 @@ endmodule
 }
 
 #[test]
-#[ignore = "skipped until the pipeline implementation is updated"]
 fn test_port_feedthrough_pipeline() {
     let a = ModDef::new("A");
     a.add_port("a", IO::Input(8)).unused();
@@ -169,8 +168,8 @@ module B(
     .NumStages(32'h0000_0001)
   ) pipeline_conn_0 (
     .clk(clk),
-    .in(original[7:0]),
-    .out(flipped[7:0]),
+    .in(original),
+    .out(flipped),
     .out_stages()
   );
 endmodule
@@ -179,7 +178,6 @@ endmodule
 }
 
 #[test]
-#[ignore = "skipped until the pipeline implementation is updated"]
 fn test_port_slice_feedthrough_pipeline() {
     let a = ModDef::new("A");
     a.add_port("a", IO::Input(8)).unused();
@@ -209,8 +207,8 @@ module B(
     .NumStages(32'h0000_0001)
   ) pipeline_conn_0 (
     .clk(clk),
-    .in(original[3:0]),
-    .out(flipped[3:0]),
+    .in(original),
+    .out(flipped),
     .out_stages()
   );
 endmodule

--- a/tests/syntax/enums.rs
+++ b/tests/syntax/enums.rs
@@ -63,13 +63,13 @@ fn test_enum_type_remap_parameterized() {
     .unwrap();
 
     let mod_a = ModDef::from_verilog_file("ModA", input_verilog.path(), true, false);
-    let mod_a_parameterized = mod_a.parameterize(&[("MY_PARAM", 16)], None, None);
+    let mod_a_parameterized = mod_a.parameterize(&[("MY_PARAM", 16)]);
     let wrapped = mod_a_parameterized.wrap(None, None);
 
     assert_eq!(
         wrapped.emit(true),
         "\
-module ModA_MY_PARAM_16(
+module ModA_wrapper(
   input wire [1:0] portA,
   output wire [1:0] portB,
   input wire [7:0] portC,
@@ -80,22 +80,6 @@ module ModA_MY_PARAM_16(
     .MY_PARAM(32'h0000_0010)
   ) ModA_i (
     .portA(color_pkg::rgb_t'(portA)),
-    .portB(portB),
-    .portC(portC),
-    .portD(portD),
-    .portE(portE)
-  );
-endmodule
-
-module ModA_MY_PARAM_16_wrapper(
-  input wire [1:0] portA,
-  output wire [1:0] portB,
-  input wire [7:0] portC,
-  output wire [7:0] portD,
-  input wire [15:0] portE
-);
-  ModA_MY_PARAM_16 ModA_MY_PARAM_16_i (
-    .portA(portA),
     .portB(portB),
     .portC(portC),
     .portD(portD),

--- a/tests/syntax/import.rs
+++ b/tests/syntax/import.rs
@@ -246,12 +246,12 @@ fn test_negative_indices_parameterized() {
 
     let foo = ModDef::from_verilog_file("foo", verilog.path(), true, false);
 
-    let parameterized = foo.parameterize(&[("N", 0)], None, None);
+    let parameterized = foo.parameterize(&[("N", 0)]).wrap(None, None);
 
     assert_eq!(
         parameterized.emit(true),
         "\
-module foo_N_0(
+module foo_wrapper(
   input wire [1:0] a
 );
   foo #(


### PR DESCRIPTION
Two key changes:
1. Previously, parameterizing a `ModDef` involved creating a new `ModDef` that wrapped the original and set parameter values. This was problematic because it cluttered the global namespace of module definitions; it also had a fairly cumbersome implementation, with a mini-generator that sat outside the main Verilog `emit()` logic. Now, `emit()` directly handles module parameters and there is no wrapper level involved. This has two side benefits: (1) simpler invocation of `parameterize()` (one argument instead of three to specify details of the wrapper), and (2) modules can be reparameterized, e.g. `mod_def.parameterize(...).parameterize(...)`.
2. Previously, pipelined connections had a special mini-generator to specify the width and depth of repeaters as parameters. Now, the mini-generator is removed in favor of directly using TopStitch's ability to specify module parameters.

With these changes, TopStitch is back to its original functionality before the major connectivity refactoring effort began, so a new release will be published after this PR is merged.