### PR TITLE
Add a tieoff API

### DIFF
--- a/src/port/trace.rs
+++ b/src/port/trace.rs
@@ -7,4 +7,9 @@ impl Port {
     pub fn trace_through_hierarchy(&self) -> Option<PortSlice> {
         self.to_port_slice().trace_through_hierarchy()
     }
+
+    /// Returns `true` if any part of this port ultimately traces to a tieoff.
+    pub fn has_tieoff_connection(&self) -> bool {
+        self.to_port_slice().has_tieoff_connection()
+    }
 }

--- a/src/port_slice/trace.rs
+++ b/src/port_slice/trace.rs
@@ -89,6 +89,15 @@ impl PortSlice {
             MAX_ITERATIONS
         );
     }
+
+    /// Returns `true` if any part of this port slice ultimately traces to a tieoff.
+    /// Similar to trace_through_hierarchy above, this does not support different
+    /// parts of the `PortSlice` connecting to different places
+    pub fn has_tieoff_connection(&self) -> bool {
+        // TODO(jowright) 2026-03-25: Make this work with divergence or return a Result
+        self.get_port_connections()
+            .is_some_and(|connections| !connections.trace().to_tieoffs().is_empty())
+    }
 }
 
 #[cfg(test)]
@@ -127,6 +136,21 @@ mod tests {
             &a_inst.get_port("x").slice(3, 0),
             &b_inst.get_port("y").slice(3, 0),
         );
+    }
+
+    #[test]
+    fn test_has_tieoff_connection() {
+        let top = ModDef::new("Top");
+        let a = top.add_port("a", IO::Output(4));
+        let b = top.add_port("b", IO::Input(2));
+
+        a.slice(1, 0).tieoff(0b10u32);
+        a.slice(3, 2).connect(&b);
+
+        assert!(a.has_tieoff_connection());
+        assert!(a.slice(1, 0).has_tieoff_connection());
+        assert!(!a.slice(3, 2).has_tieoff_connection());
+        assert!(!b.has_tieoff_connection());
     }
 
     #[test]


### PR DESCRIPTION
This adds an API to indicate if a port slice is tied off. It isn't perfect but is useful if you want to generate something (CDC constraints, reports, etc.) for all tied off pins.