### PR TITLE
Add functions to retrieve connection distance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topstitch"
-version = "0.95.1"
+version = "0.96.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topstitch"
-version = "0.95.1"
+version = "0.96.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Stitch together Verilog modules with Rust"

--- a/examples/derived_pins.rs
+++ b/examples/derived_pins.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
 use topstitch::{
-    BoundingBox, Coordinate, LefDefOptions, ModDef, Orientation, Polygon, Range, SpreadPinsOptions,
-    TrackDefinition, TrackDefinitions, TrackOrientation, Usage,
+    BoundingBox, Coordinate, LefDefOptions, ModDef, ModInst, Orientation, Polygon, Port, PortSlice,
+    Range, SpreadPinsOptions, TrackDefinition, TrackDefinitions, TrackOrientation, Usage,
 };
 
 const WIDTH: i64 = 100;
@@ -110,6 +114,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     b_in.place_abutted();
     b_out.place_across_from(b_in);
 
+    // Write a CSV report of physical connection distances. The report code
+    // below starts at the supplied top module, walks every instance
+    // recursively, checks each bit of each selected physical leaf port, and
+    // merges adjacent bits back into slices when they have the same distance.
+    let csv_path = out_dir.join("derived_pins_connection_distances.csv");
+    write_connection_distance_report(&top, &csv_path)?;
+
     // Emit LEF/DEF for viewing
     let lef_path = out_dir.join("derived_pins.lef");
     let def_path = out_dir.join("derived_pins.def");
@@ -117,4 +128,152 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("emit LEF/DEF");
 
     Ok(())
+}
+
+fn write_connection_distance_report(top: &ModDef, path: &Path) -> io::Result<()> {
+    let mut report = File::create(path)?;
+    writeln!(report, "source,connected,distance")?;
+
+    for instance in top.get_instances() {
+        write_instance_connection_distances(&instance, &mut report)?;
+    }
+
+    Ok(())
+}
+
+fn write_instance_connection_distances(
+    instance: &ModInst,
+    report: &mut dyn Write,
+) -> io::Result<()> {
+    // Only physical leaf modules have meaningful leaf pins in this example.
+    // Additional report filters could be added here, for example by matching
+    // module names, instance names, or port names before iterating ports.
+    if instance.get_mod_def().get_usage() == Usage::EmitStubAndStop {
+        for port in instance.get_ports(None) {
+            write_port_connection_distances(&port, report)?;
+        }
+    }
+
+    for child in instance.get_instances() {
+        write_instance_connection_distances(&child, report)?;
+    }
+
+    Ok(())
+}
+
+fn write_port_connection_distances(port: &Port, report: &mut dyn Write) -> io::Result<()> {
+    let mut runs: Vec<ConnectionDistanceRun> = Vec::new();
+
+    for bit in 0..port.io().width() {
+        let source = port.bit(bit);
+        let Some((connected, distance)) = source.get_connected_port_slice_and_distance() else {
+            continue;
+        };
+
+        if let Some(run) = runs.last_mut()
+            && run.try_extend(&source, &connected, distance)
+        {
+            continue;
+        }
+
+        runs.push(ConnectionDistanceRun::new(&source, &connected, distance));
+    }
+
+    for run in runs {
+        write_connection_distance_run(&run, report)?;
+    }
+
+    Ok(())
+}
+
+fn write_connection_distance_run(
+    run: &ConnectionDistanceRun,
+    report: &mut dyn Write,
+) -> io::Result<()> {
+    let source = run.source_port.slice(run.source_msb, run.source_lsb);
+    let connected = run
+        .connected_port
+        .slice(run.connected_msb, run.connected_lsb);
+    let source_name = format_port_slice_for_report(&source);
+    let connected_name = format_port_slice_for_report(&connected);
+    writeln!(
+        report,
+        "{},{},{}",
+        csv_field(&source_name),
+        csv_field(&connected_name),
+        run.distance
+    )
+}
+
+struct ConnectionDistanceRun {
+    source_port: Port,
+    source_lsb: usize,
+    source_msb: usize,
+    connected_port: Port,
+    connected_lsb: usize,
+    connected_msb: usize,
+    connected_last_bit: usize,
+    connected_step: Option<isize>,
+    distance: i64,
+}
+
+impl ConnectionDistanceRun {
+    fn new(source: &PortSlice, connected: &PortSlice, distance: i64) -> Self {
+        let connected_bit = connected.lsb();
+        Self {
+            source_port: source.get_port(),
+            source_lsb: source.lsb(),
+            source_msb: source.msb(),
+            connected_port: connected.get_port(),
+            connected_lsb: connected_bit,
+            connected_msb: connected_bit,
+            connected_last_bit: connected_bit,
+            connected_step: None,
+            distance,
+        }
+    }
+
+    fn try_extend(&mut self, source: &PortSlice, connected: &PortSlice, distance: i64) -> bool {
+        if source.lsb() != self.source_msb + 1
+            || source.get_port() != self.source_port
+            || connected.get_port() != self.connected_port
+            || distance != self.distance
+        {
+            return false;
+        }
+
+        let connected_bit = connected.lsb();
+        let step = connected_bit as isize - self.connected_last_bit as isize;
+        if !matches!(step, -1 | 1) {
+            return false;
+        }
+
+        if let Some(existing_step) = self.connected_step
+            && step != existing_step
+        {
+            return false;
+        }
+
+        self.source_msb = source.msb();
+        self.connected_lsb = self.connected_lsb.min(connected_bit);
+        self.connected_msb = self.connected_msb.max(connected_bit);
+        self.connected_last_bit = connected_bit;
+        self.connected_step = Some(step);
+        true
+    }
+}
+
+fn format_port_slice_for_report(port_slice: &PortSlice) -> String {
+    let name = format!("{port_slice:?}");
+    if port_slice.lsb() == port_slice.msb() {
+        let bit_suffix = format!("[{}:{}]", port_slice.lsb(), port_slice.lsb());
+        if let Some(prefix) = name.strip_suffix(&bit_suffix) {
+            return format!("{prefix}[{}]", port_slice.lsb());
+        }
+    }
+    name
+}
+
+fn csv_field(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
 }

--- a/src/mod_inst.rs
+++ b/src/mod_inst.rs
@@ -8,8 +8,7 @@ use std::sync::{Arc, Weak};
 use num_bigint::BigInt;
 
 use crate::{
-    BoundingBox, ConvertibleToModDef, Intf, MetadataKey, MetadataValue, ModDef, ModDefCore, Port,
-    PortSlice,
+    ConvertibleToModDef, Intf, MetadataKey, MetadataValue, ModDef, ModDefCore, Port, PortSlice,
 };
 use crate::{Coordinate, Mat3, Orientation, PhysicalPin, Placement};
 
@@ -282,59 +281,24 @@ impl ModInst {
 
                 let self_port_slice = self_port.bit(bit);
 
-                let other_port_slice = match self_port_slice.trace_through_hierarchy() {
-                    Some(other) => other,
-                    None => continue,
-                };
-
-                if other_port_slice.lsb != other_port_slice.msb {
-                    panic!(
-                        "Found multi-bit port slice {} when validating connection distance for bit {}",
-                        other_port_slice.debug_string(),
-                        self.debug_string()
-                    );
-                }
-
-                let other_mod_inst =
-                    if let Some(other_mod_inst) = other_port_slice.port.get_mod_inst() {
-                        other_mod_inst
-                    } else {
-                        // Top-level port
-                        continue;
-                    };
-
-                let other_transform = other_mod_inst.get_transform();
-                let other_port_name = other_port_slice.port.name();
-                let other_mod_def_core = other_mod_inst.get_mod_def().core;
-                let other_mod_def_core_borrowed = other_mod_def_core.read();
-                let Some(other_physical_pin) = other_mod_def_core_borrowed
-                    .physical_pins
-                    .get(other_port_name)
-                    .and_then(|pins| pins.get(other_port_slice.lsb))
-                    .and_then(|pin| pin.as_ref())
+                let Some((other_port_slice, manhattan_distance)) = self_port_slice
+                    .get_connected_bit_and_distance_with_self_transform(
+                        &self_transform,
+                        self_physical_pin,
+                    )
                 else {
                     continue;
                 };
 
-                let self_pin_bbox = self_physical_pin
-                    .transformed_polygon()
-                    .apply_transform(&self_transform)
-                    .bbox();
-                let other_pin_bbox: BoundingBox = other_physical_pin
-                    .transformed_polygon()
-                    .apply_transform(&other_transform)
-                    .bbox();
-
-                let manhattan_distance = self_pin_bbox.gap(&other_pin_bbox);
-
-                assert!(
-                    manhattan_distance <= max_distance,
-                    "Distance between {} and {} is {}, exceeding the max specified distance of {}",
-                    self_port_slice.debug_string(),
-                    other_port_slice.debug_string(),
-                    manhattan_distance,
-                    max_distance,
-                );
+                if manhattan_distance > max_distance {
+                    panic!(
+                        "Distance between {} and {} is {}, exceeding the max specified distance of {}",
+                        self_port_slice.debug_string(),
+                        other_port_slice.debug_string(),
+                        manhattan_distance,
+                        max_distance,
+                    );
+                }
             }
         }
     }

--- a/src/port/trace.rs
+++ b/src/port/trace.rs
@@ -8,6 +8,19 @@ impl Port {
         self.to_port_slice().trace_through_hierarchy()
     }
 
+    /// See documentation for [`PortSlice::get_connection_distance()`]. This
+    /// currently supports only single-bit ports.
+    pub fn get_connection_distance(&self) -> Option<i64> {
+        self.to_port_slice().get_connection_distance()
+    }
+
+    /// See documentation for
+    /// [`PortSlice::get_connected_port_slice_and_distance()`]. This currently
+    /// supports only single-bit ports.
+    pub fn get_connected_port_slice_and_distance(&self) -> Option<(PortSlice, i64)> {
+        self.to_port_slice().get_connected_port_slice_and_distance()
+    }
+
     /// Returns `true` if any part of this port ultimately traces to a tieoff.
     pub fn has_tieoff_connection(&self) -> bool {
         self.to_port_slice().has_tieoff_connection()

--- a/src/port_slice/trace.rs
+++ b/src/port_slice/trace.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Port, PortSlice, Usage};
+use crate::{Mat3, PhysicalPin, Port, PortSlice, Usage};
 use std::collections::HashSet;
 
 const MAX_ITERATIONS: usize = 1000;
@@ -21,6 +21,10 @@ impl PortSlice {
     /// (3) This `PortSlice` is connected to another `PortSlice` using multiple
     ///     `connect()` operations.
     pub fn trace_through_hierarchy(&self) -> Option<PortSlice> {
+        self.trace_through_hierarchy_impl(false)
+    }
+
+    fn trace_through_hierarchy_impl(&self, return_none_on_error: bool) -> Option<PortSlice> {
         let width = self.width();
 
         let mut hierarchy = match &self.port {
@@ -33,10 +37,14 @@ impl PortSlice {
 
         for _ in 0..MAX_ITERATIONS {
             if !visited.insert(current.clone()) {
-                panic!(
-                    "Failed to trace {} due to an infinite loop",
-                    current.debug_string()
-                );
+                if return_none_on_error {
+                    return None;
+                } else {
+                    panic!(
+                        "Failed to trace {} due to an infinite loop",
+                        current.debug_string()
+                    );
+                }
             }
 
             let connections = current.get_port_connections()?;
@@ -48,7 +56,13 @@ impl PortSlice {
             let connection = match connections_filtered.len() {
                 0 => return None,
                 1 => connections_filtered.first().unwrap(),
-                _ => panic!("Failed to trace {} due to fanout", self.debug_string(),),
+                _ => {
+                    if return_none_on_error {
+                        return None;
+                    } else {
+                        panic!("Failed to trace {} due to fanout", self.debug_string());
+                    }
+                }
             };
 
             if matches!(current.port, Port::ModInst { .. }) {
@@ -83,11 +97,105 @@ impl PortSlice {
             };
         }
 
-        panic!(
-            "Failed to trace {} after {} iterations",
-            self.debug_string(),
-            MAX_ITERATIONS
+        if return_none_on_error {
+            None
+        } else {
+            panic!(
+                "Failed to trace {} after {} iterations",
+                self.debug_string(),
+                MAX_ITERATIONS
+            );
+        }
+    }
+
+    /// Returns the Manhattan gap between this ModInst port slice's physical
+    /// pin and the physical pin it traces to.
+    ///
+    /// This currently supports only single-bit ModInst port slices. Wider port
+    /// slices may be supported in the future, but for now this panics if called
+    /// on a multi-bit slice.
+    ///
+    /// Returns `None` when the bit is tied off, unconnected, has multi-fanout,
+    /// hits another trace error, traces to a top-level port, or either side
+    /// does not have a physical pin.
+    pub fn get_connection_distance(&self) -> Option<i64> {
+        self.get_connected_port_slice_and_distance()
+            .map(|(_, distance)| distance)
+    }
+
+    /// Returns the ModInst port slice connected to this ModInst port slice,
+    /// along with the Manhattan gap between their physical pins.
+    ///
+    /// This currently supports only single-bit ModInst port slices. Wider port
+    /// slices may be supported in the future, but for now this panics if called
+    /// on a multi-bit slice.
+    ///
+    /// Returns `None` when the bit is tied off, unconnected, has multi-fanout,
+    /// hits another trace error, traces to a top-level port, or either side
+    /// does not have a physical pin.
+    pub fn get_connected_port_slice_and_distance(&self) -> Option<(PortSlice, i64)> {
+        let Some(self_mod_inst) = self.port.get_mod_inst() else {
+            panic!(
+                "get_connected_port_slice_and_distance only works on ports (or slices of ports) on module instances"
+            );
+        };
+
+        let self_transform = self_mod_inst.get_transform();
+
+        // TODO(sherbst) 2026-04-30: Support multi-bit port slices by returning a
+        // matching-width connected PortSlice and an aggregate distance, such as
+        // the maximum bit distance. Decide how to represent cases without a
+        // single connected PortSlice covering the full width; one option is to
+        // return the PortSlice associated with the longest-distance bit.
+        let self_physical_pin = self.get_local_physical_pin()?;
+        self.get_connected_bit_and_distance_with_self_transform(&self_transform, &self_physical_pin)
+    }
+
+    /// Crate-internal fast path for callers that already know this slice's
+    /// instance transform and physical pin, such as per-bit validation loops.
+    /// This avoids recomputing `ModInst::get_transform()` and re-reading the
+    /// physical pin map for every bit.
+    pub(crate) fn get_connected_bit_and_distance_with_self_transform(
+        &self,
+        self_transform: &Mat3,
+        self_physical_pin: &PhysicalPin,
+    ) -> Option<(PortSlice, i64)> {
+        self.check_validity();
+        assert!(
+            matches!(self.port, Port::ModInst { .. }),
+            "get_connected_bit_and_distance_with_self_transform requires a port slice on a module instance"
         );
+
+        let other = self.trace_through_hierarchy_impl(true)?;
+        let other_mod_inst = other.port.get_mod_inst()?;
+        let other_transform = other_mod_inst.get_transform();
+        let other_physical_pin = other.get_local_physical_pin()?;
+
+        let distance = physical_pin_distance(
+            self_transform,
+            self_physical_pin,
+            &other_transform,
+            &other_physical_pin,
+        );
+
+        Some((other, distance))
+    }
+
+    fn get_local_physical_pin(&self) -> Option<PhysicalPin> {
+        assert!(
+            self.width() == 1,
+            "physical pin lookup currently only supports single-bit port slices (called on {})",
+            self.debug_string()
+        );
+
+        self.port
+            .get_mod_def_core_where_declared()
+            .read()
+            .physical_pins
+            .get(self.port.name())
+            .and_then(|pins| pins.get(self.lsb))
+            .and_then(|pin| pin.as_ref())
+            .cloned()
     }
 
     /// Returns `true` if any part of this port slice ultimately traces to a tieoff.
@@ -98,6 +206,24 @@ impl PortSlice {
         self.get_port_connections()
             .is_some_and(|connections| !connections.trace().to_tieoffs().is_empty())
     }
+}
+
+fn physical_pin_distance(
+    a_transform: &Mat3,
+    a_physical_pin: &PhysicalPin,
+    b_transform: &Mat3,
+    b_physical_pin: &PhysicalPin,
+) -> i64 {
+    let a_bbox = a_physical_pin
+        .transformed_polygon()
+        .apply_transform(a_transform)
+        .bbox();
+    let b_bbox = b_physical_pin
+        .transformed_polygon()
+        .apply_transform(b_transform)
+        .bbox();
+
+    a_bbox.gap(&b_bbox)
 }
 
 #[cfg(test)]

--- a/tests/mod_inst_distance.rs
+++ b/tests/mod_inst_distance.rs
@@ -2,6 +2,23 @@
 
 use topstitch::*;
 
+fn single_pin_mod(name: &str, port_name: &str, io: IO) -> ModDef {
+    let module = ModDef::new(name);
+    module.set_usage(Usage::EmitStubAndStop);
+    module.set_width_height(4, 4);
+    module.add_port(port_name, io);
+    module.place_pin(
+        port_name,
+        0,
+        PhysicalPin::from_translation(
+            "M1",
+            Polygon::from_width_height(2, 2),
+            Coordinate { x: 1, y: 1 },
+        ),
+    );
+    module
+}
+
 #[test]
 fn test_mod_inst_validate_connection_distances_ok() {
     let a = ModDef::new("A");
@@ -86,6 +103,101 @@ fn test_mod_inst_validate_connection_distances_with_overlap() {
     a_inst.get_port("x").connect(&b_inst.get_port("y"));
 
     a_inst.validate_connection_distances();
+}
+
+#[test]
+fn test_connection_distance_with_gap() {
+    let a = single_pin_mod("A", "x", IO::Output(1));
+    let b = single_pin_mod("B", "y", IO::Input(1));
+
+    let top = ModDef::new("Top");
+    let a_inst = top.instantiate(&a, Some("a_inst"), None);
+    let b_inst = top.instantiate(&b, Some("b_inst"), None);
+    a_inst.place((0, 0), Orientation::R0);
+    b_inst.place((7, 0), Orientation::R0);
+
+    a_inst.get_port("x").connect(&b_inst.get_port("y"));
+
+    assert_eq!(
+        a_inst
+            .get_port("x")
+            .bit(0)
+            .get_connected_port_slice_and_distance(),
+        Some((b_inst.get_port("y").bit(0), 5))
+    );
+    assert_eq!(
+        a_inst.get_port("x").bit(0).get_connection_distance(),
+        Some(5)
+    );
+    assert_eq!(
+        b_inst.get_port("y").bit(0).get_connection_distance(),
+        Some(5)
+    );
+}
+
+#[test]
+#[should_panic(expected = "physical pin lookup currently only supports single-bit port slices")]
+fn test_connection_distance_multibit_panics() {
+    let a = ModDef::new("A");
+    a.add_port("x", IO::Output(2));
+
+    let top = ModDef::new("Top");
+    let a_inst = top.instantiate(&a, Some("a_inst"), None);
+
+    a_inst.get_port("x").get_connection_distance();
+}
+
+#[test]
+fn test_connection_distance_tieoff_returns_none() {
+    let a = single_pin_mod("A", "x", IO::Input(1));
+
+    let top = ModDef::new("Top");
+    let a_inst = top.instantiate(&a, Some("a_inst"), None);
+    a_inst.place((0, 0), Orientation::R0);
+
+    a_inst.get_port("x").tieoff(0);
+
+    assert_eq!(a_inst.get_port("x").bit(0).get_connection_distance(), None);
+}
+
+#[test]
+fn test_connection_distance_multi_fanout_returns_none() {
+    let a = single_pin_mod("A", "x", IO::Output(1));
+    let b = single_pin_mod("B", "y", IO::Input(1));
+    let c = single_pin_mod("C", "z", IO::Input(1));
+
+    let top = ModDef::new("Top");
+    let a_inst = top.instantiate(&a, Some("a_inst"), None);
+    let b_inst = top.instantiate(&b, Some("b_inst"), None);
+    let c_inst = top.instantiate(&c, Some("c_inst"), None);
+    a_inst.place((0, 0), Orientation::R0);
+    b_inst.place((4, 0), Orientation::R0);
+    c_inst.place((8, 0), Orientation::R0);
+
+    a_inst.get_port("x").connect(&b_inst.get_port("y"));
+    a_inst.get_port("x").connect(&c_inst.get_port("z"));
+
+    assert_eq!(a_inst.get_port("x").bit(0).get_connection_distance(), None);
+}
+
+#[test]
+fn test_connection_distance_trace_error_returns_none() {
+    let a = ModDef::new("A");
+    a.add_port("x", IO::Output(1));
+
+    let b = a.wrap(Some("B"), Some("a_inst"));
+    let b_inst_in_a = a.instantiate(&b, Some("b_inst"), None);
+    b_inst_in_a.get_port("x").connect(&a.get_port("x"));
+
+    let d = ModDef::new("D");
+    d.add_port("p", IO::Input(1));
+
+    let top = ModDef::new("Top");
+    let b_inst = top.instantiate(&b, Some("b_inst"), None);
+    let d_inst = top.instantiate(&d, Some("d_inst"), None);
+    d_inst.get_port("p").connect(&b_inst.get_port("x"));
+
+    assert_eq!(d_inst.get_port("p").bit(0).get_connection_distance(), None);
 }
 
 #[test]


### PR DESCRIPTION
The main two functions added are:

`PortSlice.get_connection_distance() -> Option<i64>`
`PortSlice.get_connected_port_slice_and_distance() -> Option<(PortSlice, i64)>`

Limited to single-bit `Port` and `PortSlice` types, and will return `None` if there is a tieoff or multi-fanout.

I included some sample application code in `examples/derived_pins.rs` to show how these features can be used to write a report of connection distances for multi-bit ports, over a module hierarchy.